### PR TITLE
init training scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ SECRETS.py
 .ipynb_checkpoints
 sandbox/
 results/
+checkpoints/
+lightning_logs/
+tea_debug.log
+pyrightconfig.json

--- a/notebooks/03_gnn_model.py
+++ b/notebooks/03_gnn_model.py
@@ -20,7 +20,6 @@ def _():
     return (
         AtomAttributionExplainer,
         ChemBertaEncoder,
-        LipophilicityGNN,
         build_chemprop_dataset,
         evaluate_gnn,
         get_splits,
@@ -77,7 +76,11 @@ def _(ckpt_input, load_checkpoint, torch):
 
 @app.cell
 def _(mo):
-    mo.md("## Data")
+    mo.md(
+        """
+    ## Data
+    """
+    )
     return
 
 
@@ -88,7 +91,7 @@ def _(ChemBertaEncoder, device, get_splits):
     lm_embs = {
         name: encoder.encode(split["Drug"].tolist()) for name, split in splits.items()
     }
-    return encoder, lm_embs, splits
+    return lm_embs, splits
 
 
 @app.cell
@@ -107,12 +110,116 @@ def _(mo, splits):
 
 @app.cell
 def _(mo):
-    mo.md("## Metrics")
+    mo.md(
+        """
+    ## Training Curves
+    """
+    )
     return
 
 
 @app.cell
-def _(build_chemprop_dataset, device, evaluate_gnn, lm_embs, mo, model, pd, splits):
+def _(ckpt_input, mo, pd):
+    def _():
+        import glob as _glob
+        import os as _os
+
+        import matplotlib.pyplot as plt
+
+        _path = ckpt_input.value.strip()
+        _ckpt_dir = (
+            _os.path.dirname(_path) if _path.endswith(".ckpt") else _path.rstrip("/")
+        )
+
+        # Prefer the stable copy written by train_gnn; fall back to the versioned CSVLogger path.
+        _csv_path = _os.path.join(_ckpt_dir, "metrics_history.csv")
+        if not _os.path.exists(_csv_path):
+            _candidates = sorted(
+                _glob.glob(
+                    _os.path.join(_ckpt_dir, "logs", "**", "metrics.csv"),
+                    recursive=True,
+                )
+            )
+            if _candidates:
+                _csv_path = _candidates[-1]  # latest version
+
+        if not _os.path.exists(_csv_path):
+            return mo.callout(
+                mo.md(f"No metrics CSV found under `{_ckpt_dir}`. Run training first."),
+                kind="warn",
+            )
+
+        _df = pd.read_csv(_csv_path)
+        _window = 5
+        _colors = {"train": "#4e79a7", "val": "#e15759"}
+
+        fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+        for _ax, _metric, _ylabel in zip(axes, ["loss", "mae"], ["MSE Loss", "MAE"]):
+            for _split in ("train", "val"):
+                _col = f"{_split}_{_metric}"
+                if _col not in _df.columns:
+                    continue
+                _sub = _df[["epoch", _col]].dropna(subset=[_col])
+                _by_epoch = _sub.groupby("epoch")[_col].mean()
+                _ax.plot(
+                    _by_epoch.index,
+                    _by_epoch.values,
+                    alpha=0.3,
+                    color=_colors[_split],
+                    linewidth=0.8,
+                )
+                _ax.plot(
+                    _by_epoch.index,
+                    _by_epoch.rolling(_window, min_periods=1).mean(),
+                    color=_colors[_split],
+                    linewidth=2,
+                    label=f"{_split} ({_window}-ep mean)",
+                )
+            _ax.set_xlabel("Epoch")
+            _ax.set_ylabel(_ylabel)
+            _ax.set_title(f"{_ylabel} vs Epoch")
+            _ax.legend(fontsize=9)
+
+        plt.tight_layout()
+        return mo.vstack(
+            [
+                fig,
+                mo.callout(
+                    mo.md(
+                        "The raw val curve is rough because ~500 validation molecules produce "
+                        "only ~8 batches per epoch — epoch means have high variance. "
+                        "The bold line is a rolling mean showing the underlying trend."
+                    ),
+                    kind="info",
+                ),
+            ]
+        )
+
+    _()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+    ## Metrics
+    """
+    )
+    return
+
+
+@app.cell
+def _(
+    build_chemprop_dataset,
+    device,
+    evaluate_gnn,
+    lm_embs,
+    mo,
+    model,
+    pd,
+    splits,
+):
     from chemprop.data import build_dataloader as _bdl
 
     _loaders = {
@@ -138,12 +245,16 @@ def _(build_chemprop_dataset, device, evaluate_gnn, lm_embs, mo, model, pd, spli
     ]
     results_df = pd.DataFrame(_rows).round(3)
     mo.vstack([mo.md("### Per-split metrics"), mo.ui.table(results_df)])
-    return (results_df,)
+    return
 
 
 @app.cell
 def _(mo):
-    mo.md("## Parity Plot")
+    mo.md(
+        """
+    ## Parity Plot
+    """
+    )
     return
 
 
@@ -170,9 +281,10 @@ def _(build_chemprop_dataset, device, lm_embs, mo, model, np, splits, torch):
             model.eval()
             with torch.no_grad():
                 for _batch in _loader:
+                    _batch.bmg.to(device)
                     _preds.append(
                         model(
-                            _batch.bmg.to(device),
+                            _batch.bmg,
                             _batch.X_d.to(device) if _batch.X_d is not None else None,
                         )
                         .squeeze(-1)
@@ -277,27 +389,76 @@ def _(
 def _(mo):
     mo.md(
         """
-    ## ChemBERTa Ablation
+    ## Component Ablation
 
-    Zeroing out `h_lm` measures the marginal contribution of the LLM context.
+    Measures the marginal contribution of each component by zeroing it out at
+    inference time.  Note that zeroing either input is out-of-distribution for a
+    jointly trained model, so these numbers understate the true standalone value of
+    each component — use them as a relative comparison, not an absolute score.
+
+    | Condition | What is zeroed |
+    |-----------|----------------|
+    | GNN + ChemBERTa | — (full model) |
+    | GNN only (`h_lm = 0`) | ChemBERTa `[CLS]` vector |
+    | ChemBERTa only (`h_graph = 0`) | Attention-pooled graph embedding |
     """
     )
     return
 
 
 @app.cell
-def _(build_chemprop_dataset, device, lm_embs, mo, model, np, pd, splits, torch):
+def _(
+    build_chemprop_dataset,
+    device,
+    lm_embs,
+    mo,
+    model,
+    np,
+    pd,
+    splits,
+    torch,
+):
     from chemprop.data import build_dataloader as _bdl2
     from sklearn.metrics import mean_absolute_error as _mae
     from sklearn.metrics import mean_squared_error as _mse
     from sklearn.metrics import r2_score as _r2
 
+    def _infer(loader, zero_graph=False):
+        """Run inference, optionally zeroing the pooled graph embedding via a hook."""
+        _preds, _targets = [], []
+        _hook = None
+        if zero_graph:
+
+            def _zero_hook(module, inp, out):
+                return torch.zeros_like(out)
+
+            _hook = model.pool.register_forward_hook(_zero_hook)
+        model.eval()
+        with torch.no_grad():
+            for _batch in loader:
+                _batch.bmg.to(device)
+                _preds.append(
+                    model(
+                        _batch.bmg,
+                        _batch.X_d.to(device) if _batch.X_d is not None else None,
+                    )
+                    .squeeze(-1)
+                    .cpu()
+                    .numpy()
+                )
+                _targets.append(_batch.Y.squeeze(-1).numpy())
+        if _hook is not None:
+            _hook.remove()
+        return np.concatenate(_preds), np.concatenate(_targets)
+
     _ablation_rows = []
     for _split in ("valid", "test"):
-        for _label, _lm_use in [
-            ("GNN + ChemBERTa", lm_embs[_split]),
-            ("GNN only (h_lm=0)", np.zeros_like(lm_embs[_split])),
-        ]:
+        _conditions = [
+            ("GNN + ChemBERTa", lm_embs[_split], False),
+            ("GNN only (h_lm=0)", np.zeros_like(lm_embs[_split]), False),
+            ("ChemBERTa only (h_graph=0)", lm_embs[_split], True),
+        ]
+        for _label, _lm_use, _zero_graph in _conditions:
             _loader = _bdl2(
                 build_chemprop_dataset(
                     splits[_split]["Drug"], splits[_split]["Y"].values, _lm_use
@@ -305,22 +466,7 @@ def _(build_chemprop_dataset, device, lm_embs, mo, model, np, pd, splits, torch)
                 batch_size=64,
                 shuffle=False,
             )
-            _preds, _targets = [], []
-            model.eval()
-            with torch.no_grad():
-                for _batch in _loader:
-                    _preds.append(
-                        model(
-                            _batch.bmg.to(device),
-                            _batch.X_d.to(device) if _batch.X_d is not None else None,
-                        )
-                        .squeeze(-1)
-                        .cpu()
-                        .numpy()
-                    )
-                    _targets.append(_batch.Y.squeeze(-1).numpy())
-            _y_pred = np.concatenate(_preds)
-            _y_true = np.concatenate(_targets)
+            _y_pred, _y_true = _infer(_loader, zero_graph=_zero_graph)
             _ablation_rows.append(
                 {
                     "split": _split,
@@ -333,7 +479,7 @@ def _(build_chemprop_dataset, device, lm_embs, mo, model, np, pd, splits, torch)
 
     ablation_df = pd.DataFrame(_ablation_rows)
     mo.vstack([mo.md("### Ablation results"), mo.ui.table(ablation_df)])
-    return (ablation_df,)
+    return
 
 
 if __name__ == "__main__":

--- a/notebooks/03_gnn_model.py
+++ b/notebooks/03_gnn_model.py
@@ -1,0 +1,340 @@
+import marimo
+
+__generated_with = "0.23.1"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import numpy as np
+    import pandas as pd
+    import torch
+
+    from src.data import get_splits
+    from src.explain import AtomAttributionExplainer, plot_atom_contributions
+    from src.gnn_model import LipophilicityGNN
+    from src.graph_data import ChemBertaEncoder, build_chemprop_dataset
+    from src.train_gnn import evaluate_gnn, load_checkpoint
+
+    return (
+        AtomAttributionExplainer,
+        ChemBertaEncoder,
+        LipophilicityGNN,
+        build_chemprop_dataset,
+        evaluate_gnn,
+        get_splits,
+        load_checkpoint,
+        mo,
+        np,
+        pd,
+        plot_atom_contributions,
+        torch,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+    # GNN + ChemBERTa — Evaluation Dashboard
+
+    Train the model first:
+    ```
+    pixi run train-gnn
+    ```
+    Then point the path below at the best checkpoint to explore results.
+    """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    ckpt_input = mo.ui.text(
+        label="Checkpoint path",
+        value="checkpoints/",
+        placeholder="checkpoints/gnn-best-*.ckpt",
+    )
+    ckpt_input
+    return (ckpt_input,)
+
+
+@app.cell
+def _(ckpt_input, load_checkpoint, torch):
+    import glob as _glob
+
+    _path = ckpt_input.value.strip()
+    # Expand a directory to the best checkpoint inside it.
+    if _path.endswith("/") or not _path.endswith(".ckpt"):
+        _matches = sorted(_glob.glob(f"{_path}**/*.ckpt", recursive=True))
+        _path = _matches[-1] if _matches else _path  # last = highest epoch number
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = load_checkpoint(_path, device=device)
+    return device, model
+
+
+@app.cell
+def _(mo):
+    mo.md("## Data")
+    return
+
+
+@app.cell
+def _(ChemBertaEncoder, device, get_splits):
+    splits = get_splits()
+    encoder = ChemBertaEncoder().to(device)
+    lm_embs = {
+        name: encoder.encode(split["Drug"].tolist()) for name, split in splits.items()
+    }
+    return encoder, lm_embs, splits
+
+
+@app.cell
+def _(mo, splits):
+    mo.md(
+        f"""
+    | Split | Molecules | Target mean ± std |
+    |-------|-----------|-------------------|
+    | train | {len(splits['train'])} | {splits['train']['Y'].mean():.2f} ± {splits['train']['Y'].std():.2f} |
+    | valid | {len(splits['valid'])} | {splits['valid']['Y'].mean():.2f} ± {splits['valid']['Y'].std():.2f} |
+    | test  | {len(splits['test'])}  | {splits['test']['Y'].mean():.2f} ± {splits['test']['Y'].std():.2f}  |
+    """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("## Metrics")
+    return
+
+
+@app.cell
+def _(build_chemprop_dataset, device, evaluate_gnn, lm_embs, mo, model, pd, splits):
+    from chemprop.data import build_dataloader as _bdl
+
+    _loaders = {
+        name: _bdl(
+            build_chemprop_dataset(
+                splits[name]["Drug"],
+                splits[name]["Y"].values,
+                lm_embs[name],
+            ),
+            batch_size=64,
+            shuffle=False,
+        )
+        for name in ("train", "valid", "test")
+    }
+
+    _rows = [
+        {
+            "split": split,
+            "model": "GNN+ChemBERTa",
+            **evaluate_gnn(model, loader, device),
+        }
+        for split, loader in _loaders.items()
+    ]
+    results_df = pd.DataFrame(_rows).round(3)
+    mo.vstack([mo.md("### Per-split metrics"), mo.ui.table(results_df)])
+    return (results_df,)
+
+
+@app.cell
+def _(mo):
+    mo.md("## Parity Plot")
+    return
+
+
+@app.cell
+def _(build_chemprop_dataset, device, lm_embs, mo, model, np, splits, torch):
+    def _():
+        import matplotlib.pyplot as plt
+        from chemprop.data import build_dataloader as _dl
+        from sklearn.metrics import r2_score
+
+        _colors = {"train": "#4e79a7", "valid": "#f28e2b", "test": "#e15759"}
+        fig, ax = plt.subplots(figsize=(6, 6))
+        _all_vals = []
+
+        for _split in ("train", "valid", "test"):
+            _loader = _dl(
+                build_chemprop_dataset(
+                    splits[_split]["Drug"], splits[_split]["Y"].values, lm_embs[_split]
+                ),
+                batch_size=64,
+                shuffle=False,
+            )
+            _preds, _targets = [], []
+            model.eval()
+            with torch.no_grad():
+                for _batch in _loader:
+                    _preds.append(
+                        model(
+                            _batch.bmg.to(device),
+                            _batch.X_d.to(device) if _batch.X_d is not None else None,
+                        )
+                        .squeeze(-1)
+                        .cpu()
+                        .numpy()
+                    )
+                    _targets.append(_batch.Y.squeeze(-1).numpy())
+            _y_pred = np.concatenate(_preds)
+            _y_true = np.concatenate(_targets)
+            _r2 = r2_score(_y_true, _y_pred)
+            ax.scatter(
+                _y_true,
+                _y_pred,
+                alpha=0.5,
+                s=15,
+                color=_colors[_split],
+                label=f"{_split} (R²={_r2:.3f})",
+            )
+            _all_vals += list(_y_true) + list(_y_pred)
+
+        _lo, _hi = min(_all_vals) - 0.3, max(_all_vals) + 0.3
+        ax.plot([_lo, _hi], [_lo, _hi], "k--", linewidth=1, label="ideal")
+        ax.set_xlim(_lo, _hi)
+        ax.set_ylim(_lo, _hi)
+        ax.set_aspect("equal")
+        ax.set_xlabel("Actual logD")
+        ax.set_ylabel("Predicted logD")
+        ax.set_title("GNN + ChemBERTa — Parity Plot")
+        ax.legend(fontsize=9)
+        plt.tight_layout()
+        return mo.vstack([fig])
+
+    _()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+    ## Atom Attribution Gallery
+
+    Six molecules spanning the logD range.
+    **Red** = hydrophobic contribution (raises logD), **blue** = hydrophilic.
+    """
+    )
+    return
+
+
+@app.cell
+def _(
+    AtomAttributionExplainer,
+    device,
+    lm_embs,
+    mo,
+    model,
+    plot_atom_contributions,
+    splits,
+):
+    def _():
+        import matplotlib.pyplot as plt
+
+        explainer = AtomAttributionExplainer(model, device=device)
+        _test = splits["test"].copy().reset_index(drop=True)
+        _sorted = _test.sort_values("Y")
+        _n = len(_sorted)
+        _indices = [
+            _sorted.index[0],
+            _sorted.index[1],
+            _sorted.index[_n // 2],
+            _sorted.index[_n // 2 + 1],
+            _sorted.index[-2],
+            _sorted.index[-1],
+        ]
+        _labels = ["low", "low", "mid", "mid", "high", "high"]
+
+        figs = []
+        for _idx, _lbl in zip(_indices, _labels):
+            _smi = _test.loc[_idx, "Drug"]
+            _y = _test.loc[_idx, "Y"]
+            _lm = lm_embs["test"][_idx]
+            try:
+                _scores = explainer.explain(_smi, _lm)
+                _fig = plot_atom_contributions(
+                    _smi, _scores, title=f"{_lbl} logD  |  actual={_y:.2f}"
+                )
+            except Exception as e:
+                _fig, _ax = plt.subplots()
+                _ax.text(
+                    0.5, 0.5, f"Attribution failed:\n{e}", ha="center", va="center"
+                )
+                _ax.axis("off")
+            figs.append(_fig)
+
+        return mo.vstack([mo.hstack(figs[:3]), mo.hstack(figs[3:])])
+
+    _()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+    ## ChemBERTa Ablation
+
+    Zeroing out `h_lm` measures the marginal contribution of the LLM context.
+    """
+    )
+    return
+
+
+@app.cell
+def _(build_chemprop_dataset, device, lm_embs, mo, model, np, pd, splits, torch):
+    from chemprop.data import build_dataloader as _bdl2
+    from sklearn.metrics import mean_absolute_error as _mae
+    from sklearn.metrics import mean_squared_error as _mse
+    from sklearn.metrics import r2_score as _r2
+
+    _ablation_rows = []
+    for _split in ("valid", "test"):
+        for _label, _lm_use in [
+            ("GNN + ChemBERTa", lm_embs[_split]),
+            ("GNN only (h_lm=0)", np.zeros_like(lm_embs[_split])),
+        ]:
+            _loader = _bdl2(
+                build_chemprop_dataset(
+                    splits[_split]["Drug"], splits[_split]["Y"].values, _lm_use
+                ),
+                batch_size=64,
+                shuffle=False,
+            )
+            _preds, _targets = [], []
+            model.eval()
+            with torch.no_grad():
+                for _batch in _loader:
+                    _preds.append(
+                        model(
+                            _batch.bmg.to(device),
+                            _batch.X_d.to(device) if _batch.X_d is not None else None,
+                        )
+                        .squeeze(-1)
+                        .cpu()
+                        .numpy()
+                    )
+                    _targets.append(_batch.Y.squeeze(-1).numpy())
+            _y_pred = np.concatenate(_preds)
+            _y_true = np.concatenate(_targets)
+            _ablation_rows.append(
+                {
+                    "split": _split,
+                    "model": _label,
+                    "rmse": round(float(_mse(_y_true, _y_pred) ** 0.5), 3),
+                    "mae": round(float(_mae(_y_true, _y_pred)), 3),
+                    "r2": round(float(_r2(_y_true, _y_pred)), 3),
+                }
+            )
+
+    ablation_df = pd.DataFrame(_ablation_rows)
+    mo.vstack([mo.md("### Ablation results"), mo.ui.table(ablation_df)])
+    return (ablation_df,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,44 @@
+# notebooks/
+
+Interactive [Marimo](https://marimo.io) notebooks for data exploration and model evaluation. Notebooks are dashboards only — they visualise results produced by training scripts, they do not run training themselves.
+
+Run any notebook with:
+
+```bash
+pixi run python -m marimo run notebooks/<name>.py
+```
+
+---
+
+## Contents
+
+### `01_descriptors.py`
+
+Exploratory analysis of the raw dataset and RDKit descriptor space. Intended to be run once before model development to understand the data.
+
+- Loads the full Lipophilicity-AstraZeneca dataset and displays summary statistics.
+- Shows the logD target distribution and the fraction of molecules for which each descriptor could be computed.
+- Plots per-descriptor variance on a log scale to illustrate how many descriptors are near-zero-variance and would be removed by preprocessing.
+- Plots functional group prevalence across the dataset (via `smiles_to_fgs`).
+- Shows the ClogP (MolLogP) distribution as a sanity check against the logD target.
+
+This notebook has no outputs to persist; re-run it whenever the dataset changes.
+
+### `03_gnn_model.py`
+
+Evaluation dashboard for the trained GNN + ChemBERTa model. **Requires a trained checkpoint** — run `pixi run train-gnn` first.
+
+Point the checkpoint path input at a `.ckpt` file (or a directory; the notebook will resolve the most recent checkpoint automatically). The notebook then:
+
+1. **Loads** the model from the checkpoint via `load_checkpoint`.
+2. **Encodes** ChemBERTa embeddings for all three splits (train/valid/test) using the frozen encoder.
+3. **Metrics table** — RMSE, MAE, and R² per split.
+4. **Parity plot** — predicted vs. actual logD for all splits overlaid, coloured by split.
+5. **Atom attribution gallery** — six test-set molecules (two low, two mid, two high logD) drawn with per-atom Captum IntegratedGradients scores: red = hydrophobic contribution, blue = hydrophilic.
+6. **ChemBERTa ablation** — validation and test metrics with the ChemBERTa embedding zeroed out, quantifying the marginal accuracy contribution of the LLM context vector.
+
+---
+
+## Design note
+
+Notebooks deliberately contain no training code. Mixing training into a reactive notebook creates two problems: the reactive execution model can re-trigger expensive operations on unrelated cell edits, and training state (random seeds, shuffled batches) is harder to reproduce than a script invocation. All training lives in `scripts/` and `src/train_gnn.py`.

--- a/pixi.lock
+++ b/pixi.lock
@@ -335,6 +335,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/cd/98/da8804e01b727ed6d087055524b2b724619850270d94b14a34c833d2b47f/aimsim_core-2.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/1b/fc307991cf79f1eb6fb1eaacfa6e6cf447975b81c4b2c6c923723e5a375d/astartes-1.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/01/75/c99571fee171bb9d34d3e1df5fdb16d57e2c4c15339eb220e6e6e4539f1c/captum-0.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/60/ea/79bcd48aa127600fde283f5adb3c54a87398823f86df7ec607d3446b8134/chemprop-2.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/19/3ba5e1b0bcc7b91aeab6c258afd70e4907d220fed3972febe38feb40db30/configargparse-1.7.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7b/3c/67bfc03db3f6527a54a0f9b696809bca55eb6de27928829218ab7e6c40e7/descriptastorus-2.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/40/02/dc8584d5b477eefea7090a581312e8e3f0f5b62d144f6089311070e82c3e/mhfp-1.9.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/28/a5f6bf29558e8eaaac089aa3fcecfee2f8a44b7f4783cd86c5722f3c4530/mordredcommunity-2.0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/eb/31/75879902fbdd5079a2177845a70c5d5de2915317c1187a83af3a857e70a8/padelpy-0.1.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/04/b57109ac39c90054ca8239daa61f619042b73406309c33df06d3b73a48a7/pandas_flavor-0.8.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl
       - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -359,6 +373,21 @@ packages:
   purls: []
   size: 8191
   timestamp: 1744137672556
+- pypi: https://files.pythonhosted.org/packages/cd/98/da8804e01b727ed6d087055524b2b724619850270d94b14a34c833d2b47f/aimsim_core-2.2.3-py3-none-any.whl
+  name: aimsim-core
+  version: 2.2.3
+  sha256: 9bbc56434343dfc573e5e07731583c1f5f994f075376a87ba35a5669adf1f8b0
+  requires_dist:
+  - psutil
+  - scikit-learn
+  - rdkit
+  - numpy
+  - pandas
+  - padelpy
+  - mhfp
+  - mordredcommunity
+  - multiprocess>=0.70
+  requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
   sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
   md5: 52be5139047efadaeeb19c6a5103f92a
@@ -402,6 +431,25 @@ packages:
   - pkg:pypi/anyio?source=hash-mapping
   size: 146764
   timestamp: 1774359453364
+- pypi: https://files.pythonhosted.org/packages/37/1b/fc307991cf79f1eb6fb1eaacfa6e6cf447975b81c4b2c6c923723e5a375d/astartes-1.3.3-py3-none-any.whl
+  name: astartes
+  version: 1.3.3
+  sha256: 362447c5ceb77567dd9ea9c5a780d86fe36ba47b27184ba565ba2959a846c672
+  requires_dist:
+  - scikit-learn
+  - tabulate
+  - numpy
+  - scipy
+  - pandas
+  - aimsim-core ; extra == 'molecules'
+  - black ; extra == 'dev'
+  - isort ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - plotly ; extra == 'demos'
+  - tabulate ; extra == 'demos'
+  - py2opsin ; extra == 'demos'
+  - kaleido ; extra == 'demos'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
   sha256: ee4da0f3fe9d59439798ee399ef3e482791e48784873d546e706d0935f9ff010
   md5: 9673a61a297b00016442e022d689faa6
@@ -826,6 +874,34 @@ packages:
   purls: []
   size: 989514
   timestamp: 1766415934926
+- pypi: https://files.pythonhosted.org/packages/01/75/c99571fee171bb9d34d3e1df5fdb16d57e2c4c15339eb220e6e6e4539f1c/captum-0.9.0-py3-none-any.whl
+  name: captum
+  version: 0.9.0
+  sha256: cda38e1d42c37591d71560bb2f5813ac4cae8d8543afac45279c7efd5945997e
+  requires_dist:
+  - matplotlib
+  - numpy
+  - packaging
+  - torch>=2.3
+  - tqdm
+  - torchtext ; extra == 'tutorials'
+  - torchvision ; extra == 'tutorials'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - parameterized ; extra == 'test'
+  - black==25.11.0 ; extra == 'test'
+  - flake8 ; extra == 'test'
+  - pyre-check-nightly==0.0.101750936314 ; extra == 'test'
+  - usort==1.1.0 ; extra == 'test'
+  - ufmt ; extra == 'test'
+  - openai ; extra == 'optional'
+  - scikit-learn ; extra == 'optional'
+  - annoy ; extra == 'optional'
+  - captum[optional,test] ; extra == 'dev'
+  - sphinx<8.2.0 ; extra == 'dev'
+  - sphinx-autodoc-typehints ; extra == 'dev'
+  - sphinxcontrib-katex ; extra == 'dev'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
   sha256: 989db6e5957c4b44fa600c68c681ec2f36a55e48f7c7f1c073d5e91caa8cd878
   md5: 929471569c93acefb30282a22060dcd5
@@ -874,6 +950,52 @@ packages:
   - pkg:pypi/charset-normalizer?source=compressed-mapping
   size: 58872
   timestamp: 1775127203018
+- pypi: https://files.pythonhosted.org/packages/60/ea/79bcd48aa127600fde283f5adb3c54a87398823f86df7ec607d3446b8134/chemprop-2.2.3-py3-none-any.whl
+  name: chemprop
+  version: 2.2.3
+  sha256: 0ced4fc588c5224e5b7cf400a06adde388c8834583f04e75984003996d0367ec
+  requires_dist:
+  - lightning>=2.0
+  - numpy
+  - pandas
+  - rdkit
+  - scikit-learn
+  - scipy
+  - torch>=2.1
+  - astartes[molecules]
+  - configargparse
+  - rich
+  - descriptastorus
+  - ray[tune] ; extra == 'hpopt'
+  - hyperopt ; extra == 'hpopt'
+  - optuna ; extra == 'hpopt'
+  - pydantic ; extra == 'hpopt'
+  - setuptools<82 ; extra == 'hpopt'
+  - black==23.* ; extra == 'dev'
+  - bumpversion ; extra == 'dev'
+  - autopep8 ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - isort ; extra == 'dev'
+  - nbsphinx ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - sphinx-argparse!=0.5.0 ; extra == 'docs'
+  - sphinx-autobuild ; extra == 'docs'
+  - sphinx-autoapi ; extra == 'docs'
+  - sphinxcontrib-bibtex ; extra == 'docs'
+  - sphinx-book-theme ; extra == 'docs'
+  - nbsphinx-link ; extra == 'docs'
+  - ipykernel ; extra == 'docs'
+  - docutils<0.21 ; extra == 'docs'
+  - readthedocs-sphinx-ext ; extra == 'docs'
+  - pandoc ; extra == 'docs'
+  - pytest>=6.2 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - ipykernel ; extra == 'notebooks'
+  - matplotlib ; extra == 'notebooks'
+  - cuik-molmaker>=0.2 ; extra == 'cuik-molmaker'
+  requires_python: '>=3.11,<3.15'
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
   sha256: 526d434cf5390310f40f34ea6ec4f0c225cdf1e419010e624d399b13b2059f0f
   md5: 4d18bc3af7cfcea97bd817164672a08c
@@ -910,6 +1032,20 @@ packages:
   - pkg:pypi/comm?source=hash-mapping
   size: 14690
   timestamp: 1753453984907
+- pypi: https://files.pythonhosted.org/packages/fe/19/3ba5e1b0bcc7b91aeab6c258afd70e4907d220fed3972febe38feb40db30/configargparse-1.7.5-py3-none-any.whl
+  name: configargparse
+  version: 1.7.5
+  sha256: 1e63fdffedf94da9cd435fc13a1cd24777e76879dd2343912c1f871d4ac8c592
+  requires_dist:
+  - pyyaml ; extra == 'yaml'
+  - black ; extra == 'test'
+  - mock ; extra == 'test'
+  - toml ; extra == 'test'
+  - pyyaml ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-subtests ; extra == 'test'
+  requires_python: '>=3.6'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
   sha256: 62447faf7e8eb691e407688c0b4b7c230de40d5ecf95bf301111b4d05c5be473
   md5: 43c2bc96af3ae5ed9e8a10ded942aa50
@@ -1103,6 +1239,23 @@ packages:
   - pkg:pypi/decorator?source=hash-mapping
   size: 14129
   timestamp: 1740385067843
+- pypi: https://files.pythonhosted.org/packages/7b/3c/67bfc03db3f6527a54a0f9b696809bca55eb6de27928829218ab7e6c40e7/descriptastorus-2.8.0-py3-none-any.whl
+  name: descriptastorus
+  version: 2.8.0
+  sha256: cc0c8201d6d9d8534dc8a45ce629aeaf4cf1e62ba848b9b1e392b2600ca834dc
+  requires_dist:
+  - pandas-flavor
+  - rdkit
+  - scipy
+  - numpy
+- pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
+  name: dill
+  version: 0.4.1
+  sha256: 1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d
+  requires_dist:
+  - objgraph>=1.7.2 ; extra == 'graph'
+  - gprof2dot>=2022.7.29 ; extra == 'profile'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
   sha256: 6d977f0b2fc24fee21a9554389ab83070db341af6d6f09285360b2e09ef8b26e
   md5: 003b8ba0a94e2f1e117d0bd46aebc901
@@ -3070,6 +3223,12 @@ packages:
   - pkg:pypi/mdurl?source=hash-mapping
   size: 14465
   timestamp: 1733255681319
+- pypi: https://files.pythonhosted.org/packages/40/02/dc8584d5b477eefea7090a581312e8e3f0f5b62d144f6089311070e82c3e/mhfp-1.9.6-py3-none-any.whl
+  name: mhfp
+  version: 1.9.6
+  sha256: 164793a1c66b1b40a075accb62fb569fe8be2ee1b8146fac7e4fe087001897a8
+  requires_dist:
+  - pytest ; extra == 'dev'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2023.2.0-ha770c72_50498.conda
   sha256: cafca5b96c1431757909fa11942cb57056870d3fede2eb6bbc138f5ed86679a4
   md5: 0ef2680575d5b0d9082c287c7eef11f8
@@ -3082,6 +3241,20 @@ packages:
   purls: []
   size: 163765767
   timestamp: 1757090808863
+- pypi: https://files.pythonhosted.org/packages/2e/28/a5f6bf29558e8eaaac089aa3fcecfee2f8a44b7f4783cd86c5722f3c4530/mordredcommunity-2.0.7-py3-none-any.whl
+  name: mordredcommunity
+  version: 2.0.7
+  sha256: 36093d078df9c35419b26ca422a1c7f9ff3693b92ea5e43ea351de245f60020a
+  requires_dist:
+  - rdkit
+  - six
+  - numpy
+  - networkx
+  - packaging
+  - pandas ; extra == 'full'
+  - tqdm ; extra == 'full'
+  - pyyaml ; extra == 'full'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
   sha256: c1fdeebc9f8e4f51df265efca4ea20c7a13911193cc255db73cccb6e422ae486
   md5: 770d00bf57b5599c4544d61b61d8c6c6
@@ -3132,6 +3305,13 @@ packages:
   - pkg:pypi/msgspec?source=hash-mapping
   size: 218330
   timestamp: 1776337395109
+- pypi: https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl
+  name: multiprocess
+  version: 0.70.19
+  sha256: 3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28
+  requires_dist:
+  - dill>=0.4.1
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -3333,6 +3513,11 @@ packages:
   - pkg:pypi/packaging?source=compressed-mapping
   size: 89360
   timestamp: 1776209387231
+- pypi: https://files.pythonhosted.org/packages/eb/31/75879902fbdd5079a2177845a70c5d5de2915317c1187a83af3a857e70a8/padelpy-0.1.16-py3-none-any.whl
+  name: padelpy
+  version: 0.1.16
+  sha256: fb2814d48c498981c8ba10613e752e6ba856ccbd532aedcdc555154e87abf5b1
+  requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
   sha256: 4aad0f99a06e799acdd46af0df8f7c8273164cabce8b5c94a44b012b7d1a30a6
   md5: 42050f82a0c0f6fa23eda3d93b251c18
@@ -3390,6 +3575,14 @@ packages:
   - pkg:pypi/pandas?source=compressed-mapping
   size: 14849233
   timestamp: 1774916580467
+- pypi: https://files.pythonhosted.org/packages/30/04/b57109ac39c90054ca8239daa61f619042b73406309c33df06d3b73a48a7/pandas_flavor-0.8.1-py3-none-any.whl
+  name: pandas-flavor
+  version: 0.8.1
+  sha256: 6a74c48a7014e27117a164b687c23ca9f7da46c5b198a516ab4ebaa22435292b
+  requires_dist:
+  - pandas>=0.23
+  - xarray
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.6-pyhcf101f3_0.conda
   sha256: 42b2d77ccea60752f3aa929a6413a7835aaacdbbde679f2f5870a744fa836b94
   md5: 97c1ce2fffa1209e7afb432810ec6e12
@@ -4396,6 +4589,13 @@ packages:
   - pkg:pypi/sympy?source=hash-mapping
   size: 4661767
   timestamp: 1771952371059
+- pypi: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
+  name: tabulate
+  version: 0.10.0
+  sha256: f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
+  requires_dist:
+  - wcwidth ; extra == 'widechars'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-hb700be7_5.conda
   sha256: a49f26ddf4b954670733586e42e41e43d13f7e8e589b70ead8b7512657404d82
   md5: d4cfccb9ccd4f7cbfde7353b5e20d31a
@@ -4761,6 +4961,54 @@ packages:
   - pkg:pypi/wheel?source=compressed-mapping
   size: 33491
   timestamp: 1776878563806
+- pypi: https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl
+  name: xarray
+  version: 2026.4.0
+  sha256: d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08
+  requires_dist:
+  - numpy>=1.26
+  - packaging>=24.2
+  - pandas>=2.2
+  - scipy>=1.15 ; extra == 'accel'
+  - bottleneck ; extra == 'accel'
+  - numbagg>=0.9 ; extra == 'accel'
+  - numba>=0.62 ; extra == 'accel'
+  - flox>=0.10 ; extra == 'accel'
+  - opt-einsum ; extra == 'accel'
+  - xarray[accel,etc,io,parallel,viz] ; extra == 'complete'
+  - netcdf4>=1.6.0 ; extra == 'io'
+  - h5netcdf[h5py]>=1.5.0 ; extra == 'io'
+  - pydap ; extra == 'io'
+  - scipy>=1.15 ; extra == 'io'
+  - zarr>=3.0 ; extra == 'io'
+  - fsspec ; extra == 'io'
+  - cftime ; extra == 'io'
+  - pooch ; extra == 'io'
+  - sparse>=0.15 ; extra == 'etc'
+  - dask[complete] ; extra == 'parallel'
+  - cartopy>=0.24 ; extra == 'viz'
+  - matplotlib>=3.10 ; extra == 'viz'
+  - nc-time-axis ; extra == 'viz'
+  - seaborn ; extra == 'viz'
+  - pandas-stubs ; extra == 'types'
+  - scipy-stubs ; extra == 'types'
+  - types-colorama ; extra == 'types'
+  - types-decorator ; extra == 'types'
+  - types-defusedxml ; extra == 'types'
+  - types-docutils ; extra == 'types'
+  - types-networkx ; extra == 'types'
+  - types-openpyxl ; extra == 'types'
+  - types-pexpect ; extra == 'types'
+  - types-psutil ; extra == 'types'
+  - types-pycurl ; extra == 'types'
+  - types-pygments ; extra == 'types'
+  - types-python-dateutil ; extra == 'types'
+  - types-pytz ; extra == 'types'
+  - types-pyyaml ; extra == 'types'
+  - types-requests ; extra == 'types'
+  - types-setuptools ; extra == 'types'
+  - types-xlrd ; extra == 'types'
+  requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45

--- a/pixi.toml
+++ b/pixi.toml
@@ -45,6 +45,8 @@ pre-commit = ">=4.6.0,<5"
 
 [pypi-dependencies]
 lipophilicity-pred = { path = ".", editable = true }
+chemprop = ">=2.0"
+captum = ">=0.7"
 
 [tasks]
 # Run once after `pixi install` to get the pre-built DGL wheel for the installed torch+CUDA version
@@ -57,6 +59,9 @@ setup-dgl = """
 # both incompatible with our conda rdkit. Install without deps since rdkit,
 # pandas, numpy, scikit-learn, and tqdm are all already provided by conda.
 setup-tdc = "python -m pip install PyTDC --no-deps"
+
+# --- training ---
+train-gnn = "python scripts/train_gnn.py"
 
 # --- tests ---
 test = "pytest tests/ -v"

--- a/pixi.toml
+++ b/pixi.toml
@@ -63,5 +63,10 @@ setup-tdc = "python -m pip install PyTDC --no-deps"
 # --- training ---
 train-gnn = "python scripts/train_gnn.py"
 
+# --- notebooks ---
+# --no-token skips the login wall; safe for local/remote-SSH use
+notebook-gnn = "marimo edit --no-token notebooks/03_gnn_model.py"
+notebook-eda = "marimo edit --no-token notebooks/01_descriptors.py"
+
 # --- tests ---
 test = "pytest tests/ -v"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,52 @@
+# scripts/
+
+Training entry points for the lipophilicity prediction models. These scripts are the intended way to run model training; notebooks in `notebooks/` are reserved for evaluation and visualisation only.
+
+## Contents
+
+### `train_gnn.py`
+
+Trains the GNN + ChemBERTa model defined in `src/gnn_model.py`. Accepts hyperparameters either as CLI flags or from a YAML config file; CLI flags override the file. Writes Lightning checkpoints to `--checkpoint-dir` (default `checkpoints/`) and saves a `metrics.json` summary alongside them.
+
+**Usage**
+
+```bash
+# defaults (300-dim MPNN, 100 epochs, patience 20)
+pixi run python scripts/train_gnn.py
+
+# tune learning rate and batch size
+pixi run python scripts/train_gnn.py --lr 5e-4 --batch-size 32 --max-epochs 200
+
+# start from a YAML config, then override one key on the command line
+pixi run python scripts/train_gnn.py --config configs/gnn_base.yaml --seed 1
+
+# load a pretrained chemprop backbone checkpoint to initialise the MPNN weights
+pixi run python scripts/train_gnn.py --backbone-checkpoint path/to/pretrained.ckpt
+```
+
+**Output**
+
+- `checkpoints/gnn-best-{epoch}-{val_mae}.ckpt` — best checkpoint by validation MAE
+- `checkpoints/metrics.json` — RMSE / MAE / R² for train, valid, and test splits
+
+**YAML config format** (all keys are optional; missing keys fall back to defaults)
+
+```yaml
+d_h: 300
+d_hidden: 256
+depth: 3
+dropout: 0.0
+lr: 0.001
+weight_decay: 0.0001
+batch_size: 64
+max_epochs: 100
+patience: 20
+seed: 42
+```
+
+## Dependencies on other modules
+
+- `src/train_gnn.py` — `train_gnn()` function containing the full training pipeline
+- `src/gnn_model.py` — `LipophilicityGNN` architecture
+- `src/graph_data.py` — ChemBERTa encoder and chemprop dataset construction
+- `src/data.py` — scaffold-split data loading

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -23,6 +23,14 @@ import yaml
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    """
+    Build the argument parser for the training script.
+
+    Params:
+        None
+    Returns:
+        argparse.ArgumentParser : configured parser with all training flags
+    """
     p = argparse.ArgumentParser(
         description="Train GNN + ChemBERTa lipophilicity model",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -61,6 +69,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="directory for Lightning model checkpoints",
     )
     p.add_argument("--seed", type=int, default=None)
+    # Wandb
+    p.add_argument(
+        "--wandb-project",
+        type=str,
+        default=None,
+        help="W&B project name (default: lipophilicity_pred)",
+    )
+    p.add_argument(
+        "--wandb-run-name",
+        type=str,
+        default=None,
+        help="W&B run name; auto-generated if omitted",
+    )
     return p
 
 
@@ -94,6 +115,8 @@ def main() -> None:
         "patience": args.patience,
         "checkpoint_path": args.backbone_checkpoint,
         "seed": args.seed,
+        "wandb_project": args.wandb_project,
+        "wandb_run_name": args.wandb_run_name,
     }
     cfg.update({k: v for k, v in cli_overrides.items() if v is not None})
 

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1,0 +1,123 @@
+"""
+Train the GNN + ChemBERTa lipophilicity model.
+
+Usage
+-----
+    # defaults
+    pixi run python scripts/train_gnn.py
+
+    # common overrides
+    pixi run python scripts/train_gnn.py --lr 5e-4 --max-epochs 200 --batch-size 32
+
+    # load from a YAML config (individual flags override the file)
+    pixi run python scripts/train_gnn.py --config configs/gnn_base.yaml --seed 0
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Train GNN + ChemBERTa lipophilicity model",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="YAML config file; CLI flags override file values",
+    )
+    # Model architecture
+    p.add_argument("--d-h", type=int, default=None, help="MPNN hidden dim")
+    p.add_argument("--d-hidden", type=int, default=None, help="FusionMLP hidden dim")
+    p.add_argument("--depth", type=int, default=None, help="message-passing steps")
+    p.add_argument("--dropout", type=float, default=None)
+    # Optimisation
+    p.add_argument("--lr", type=float, default=None, help="AdamW learning rate")
+    p.add_argument("--weight-decay", type=float, default=None)
+    p.add_argument("--batch-size", type=int, default=None)
+    p.add_argument("--max-epochs", type=int, default=None)
+    p.add_argument(
+        "--patience", type=int, default=None, help="early-stopping patience (epochs)"
+    )
+    # Pretrained GNN checkpoint to initialise the backbone from
+    p.add_argument(
+        "--backbone-checkpoint",
+        type=str,
+        default=None,
+        help="chemprop .ckpt to load backbone weights from",
+    )
+    # Misc
+    p.add_argument(
+        "--checkpoint-dir",
+        type=Path,
+        default=Path("checkpoints"),
+        help="directory for Lightning model checkpoints",
+    )
+    p.add_argument("--seed", type=int, default=None)
+    return p
+
+
+def main() -> None:
+    """
+    Parse arguments, run train_gnn, and print a metrics summary.
+
+    Params:
+        None
+    Returns:
+        None
+    """
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    # Start from YAML base config if provided, then apply CLI overrides.
+    cfg: dict = {}
+    if args.config is not None:
+        with open(args.config) as f:
+            cfg = yaml.safe_load(f) or {}
+
+    cli_overrides = {
+        "d_h": args.d_h,
+        "d_hidden": args.d_hidden,
+        "depth": args.depth,
+        "dropout": args.dropout,
+        "lr": args.lr,
+        "weight_decay": args.weight_decay,
+        "batch_size": args.batch_size,
+        "max_epochs": args.max_epochs,
+        "patience": args.patience,
+        "checkpoint_path": args.backbone_checkpoint,
+        "seed": args.seed,
+    }
+    cfg.update({k: v for k, v in cli_overrides.items() if v is not None})
+
+    from src.train_gnn import (  # deferred so --help works without heavy imports
+        train_gnn,
+    )
+
+    _, metrics = train_gnn(config=cfg, checkpoint_dir=args.checkpoint_dir)
+
+    # Print a clean metrics table to stdout.
+    print("\n" + "=" * 46)
+    print(f"{'split':<8}  {'RMSE':>7}  {'MAE':>7}  {'R²':>7}")
+    print("-" * 46)
+    for split, m in metrics.items():
+        print(f"{split:<8}  {m['rmse']:>7.4f}  {m['mae']:>7.4f}  {m['r2']:>7.4f}")
+    print("=" * 46)
+
+    # Also write metrics to a JSON file beside the checkpoint dir for easy parsing.
+    out_path = Path(args.checkpoint_dir) / "metrics.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(metrics, f, indent=2)
+    print(f"\nMetrics saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,110 @@
+# src/
+
+Shared Python library for the lipophilicity prediction pipeline. All model components, data utilities, and explainability tools live here and are imported by training scripts and evaluation notebooks.
+
+---
+
+## Module contents
+
+### `data.py`
+
+Loads and splits the Lipophilicity-AstraZeneca dataset from the [Therapeutics Data Commons (TDC)](https://tdcommons.ai/).
+
+- **`load_lipophilicity()`** — returns the full dataset as a DataFrame with columns `Drug_ID`, `Drug` (SMILES), and `Y` (logD).
+- **`get_splits(seed)`** — returns a scaffold split as `{"train": ..., "valid": ..., "test": ...}`. Scaffold splitting groups structurally similar molecules into the same split, which prevents the model from exploiting near-duplicate structures that happen to be on different sides of a random split. All downstream training and evaluation uses these splits; never re-split independently.
+
+### `features.py`
+
+Computes molecule-level feature matrices from SMILES strings for the descriptor-based baseline models.
+
+- **`smiles_to_descriptors(smiles)`** — computes all ~200 RDKit descriptors (from `Descriptors._descList`) for each SMILES in a Series. Invalid SMILES produce NaN rows rather than raising or being dropped, so the output index always aligns with the input.
+- **`smiles_to_fgs(smiles)`** — binary functional group fingerprint using RDKit's built-in hierarchy (see `utils.py`). Same NaN-preservation contract as above.
+- **`get_mol_descriptors(mol)`** — per-molecule helper called internally by `smiles_to_descriptors`; wraps each descriptor in a try/except so a single failed calculation does not abort the whole molecule.
+
+### `utils.py`
+
+Functional group library management. The RDKit FG hierarchy is a nested tree; this module flattens it into a single dict and caches it at module level so the traversal only happens once per Python session.
+
+- **`get_mol_fgs(mol)`** — returns a `{fg_name: 0_or_1}` dict for one molecule; called per-molecule from `smiles_to_fgs`.
+- **`_get_fg_library()`** / **`_flatten_fgs(fgs)`** — private helpers that build and cache the flattened FG library. Do not call these directly.
+
+### `graph_data.py`
+
+Data layer for the GNN model. Bridges the HuggingFace Transformers ecosystem (ChemBERTa) with chemprop's graph data structures.
+
+- **`ChemBertaEncoder`** — frozen `seyonec/ChemBERTa-zinc-base-v1` encoder. `encode(smiles)` returns `float32` arrays of `[CLS]` hidden states. Weights are never updated during training. Must be loaded with `use_safetensors=True` on torch < 2.6 (CVE-2025-32434 blocks `torch.load` otherwise).
+- **`build_chemprop_dataset(smiles, targets, lm_embeddings)`** — creates a `chemprop.data.MoleculeDataset` where each datapoint's `x_d` field holds the precomputed ChemBERTa embedding. Embeddings are safe to precompute because the encoder is frozen. **Important:** chemprop's `TrainingBatch` exposes `x_d` as `batch.X_d`, not `batch.V_d`; `V_d` is always `None` for molecule-level extras in chemprop 2.2.x.
+
+### `gnn_model.py`
+
+Architecture for the GNN + ChemBERTa fusion model (Option A).
+
+- **`ChempropBackbone`** — wraps chemprop's `BondMessagePassing` and returns per-atom hidden states of shape `(n_atoms_total, d_h)`. Default feature dims (`d_v=72`, `d_e=14`) match chemprop's `MultiHotAtomFeaturizer` and `MultiHotBondFeaturizer`. If a checkpoint path is provided, the message-passing weights are loaded from a full chemprop `MPNN` checkpoint and the aggregation + FFN head are discarded. The hidden dimension is inferred from `W_o.out_features` after loading.
+- **`AttentionPooling`** — sigmoid-gated atom-to-molecule pooling. Uses sigmoid (not softmax) so that multiple atoms can simultaneously receive high weight; softmax would create zero-sum competition that suppresses attribution signals from co-contributing atoms.
+- **`FusionMLP`** — `LayerNorm → Linear → ReLU → Dropout → Linear → scalar`. Takes the concatenation of the graph embedding and the ChemBERTa `[CLS]` vector as input.
+- **`LipophilicityGNN`** — top-level module composing the three above. `forward(bmg, X_d)` accepts a `BatchMolGraph` and the batched ChemBERTa embeddings tensor; returns predicted logD of shape `(batch, 1)`.
+
+### `train_gnn.py`
+
+Training pipeline and utilities.
+
+- **`evaluate_gnn(model, loader, device)`** — computes RMSE, MAE, and R² over a chemprop DataLoader. Mirrors the `evaluate()` signature in the baseline models branch for consistent cross-model reporting.
+- **`GNNLitModule`** — PyTorch Lightning module wrapping `LipophilicityGNN`. Uses AdamW with cosine annealing LR. Logs `train_loss`, `train_mae`, `val_loss`, `val_mae` each step; early stopping monitors `val_mae`.
+- **`train_gnn(config, checkpoint_dir)`** — end-to-end pipeline: loads data, encodes ChemBERTa embeddings once, builds chemprop datasets, trains with Lightning, loads best checkpoint, and returns the model and final metrics. Accepts a config dict; missing keys fall back to defaults.
+- **`load_checkpoint(checkpoint_path, device, **model_kwargs)`** — restores a `LipophilicityGNN` from a Lightning `.ckpt` file. Strips the `"model."` prefix that Lightning adds to nested module state dict keys. Used by the evaluation notebook to load a trained model without re-running `train_gnn`.
+
+### `explain.py`
+
+Atom-level attribution for the trained GNN using [Captum](https://captum.ai/).
+
+- **`AtomAttributionExplainer`** — wraps Captum's `LayerIntegratedGradients` targeting `backbone.mp.W_o`, the final per-atom linear projection in the chemprop MPNN. IG integrates the gradient of the model output w.r.t. this layer's activations along a path from zero to actual, giving each atom a signed importance score. Attribution is aggregated to a scalar per atom by taking the L2 norm over the hidden dimension.
+- **`plot_atom_contributions(smiles, scores)`** — renders a 2D structure with atoms coloured by attribution score (red = positive logD contribution / hydrophobic; blue = negative / hydrophilic) using RDKit's `MolDraw2DSVG`. Scores are normalised symmetrically per molecule; the colour scale is not comparable across different molecules.
+
+---
+
+## Data contracts
+
+| Boundary | Shape / type | Notes |
+|---|---|---|
+| `get_splits()` output | `dict[str, DataFrame]`, columns `Drug_ID`, `Drug`, `Y` | `Y` is logD (float) |
+| `ChemBertaEncoder.encode()` output | `np.ndarray (n, 768)` float32 | `[CLS]` hidden state |
+| `build_chemprop_dataset()` output | `MoleculeDataset` | `x_d` per point = 768-dim LM embedding |
+| `TrainingBatch.X_d` | `Tensor (batch, 768)` | chemprop 2.2.x; field is `X_d`, **not** `V_d` |
+| `LipophilicityGNN.forward()` output | `Tensor (batch, 1)` | predicted logD, unbounded |
+| `AtomAttributionExplainer.explain()` output | `np.ndarray (n_heavy_atoms,)` float32 | L2-normed IG scores, non-negative |
+
+---
+
+## Critical parameters and constraints
+
+- `ChempropBackbone._D_V = 72` and `_D_E = 14` must match the chemprop featurizers used at graph construction time. If a custom featurizer is passed to `build_dataloader`, these defaults will be wrong and the MPNN will silently produce garbage.
+- The Captum attribution target layer is `backbone.mp.W_o`. If a future chemprop version renames this layer, attribution will fail at construction time. Inspect `list(model.backbone.mp.named_modules())` to verify.
+- ChemBERTa must be loaded with `use_safetensors=True`; torch 2.4 raises on `torch.load` for non-safetensors files due to CVE-2025-32434.
+
+---
+
+## Dependencies between modules
+
+```
+data.py
+  └── consumed by: features.py, graph_data.py (via train_gnn.py)
+
+features.py
+  └── depends on: utils.py
+
+graph_data.py
+  └── depends on: transformers (ChemBERTa), chemprop.data
+  └── consumed by: train_gnn.py, explain.py
+
+gnn_model.py
+  └── depends on: chemprop.nn, chemprop.models
+  └── consumed by: train_gnn.py, explain.py
+
+train_gnn.py
+  └── depends on: data.py, graph_data.py, gnn_model.py
+  └── consumed by: scripts/train_gnn.py, notebooks/03_gnn_model.py
+
+explain.py
+  └── depends on: gnn_model.py, graph_data.py, captum, rdkit
+  └── consumed by: notebooks/03_gnn_model.py
+```

--- a/src/data.py
+++ b/src/data.py
@@ -3,19 +3,30 @@ from tdc.single_pred import ADME
 
 
 def load_lipophilicity() -> pd.DataFrame:
-    """Load Lipophilicity-AstraZeneca from TDC.
+    """
+    Load the Lipophilicity-AstraZeneca dataset from TDC.
 
-    Returns a DataFrame with columns:
-        Drug_ID  - compound identifier
-        Drug     - SMILES string
-        Y        - logD (lipophilicity target)
+    Params:
+        None
+    Returns:
+        pd.DataFrame : columns Drug_ID (str), Drug (SMILES), Y (logD float)
     """
     data = ADME(name="Lipophilicity_AstraZeneca")
     return data.get_data()
 
 
 def get_splits(seed: int = 42) -> dict[str, pd.DataFrame]:
-    """Return the TDC scaffold-split as a dict with keys train/valid/test."""
+    """
+    Return a scaffold split of the dataset as a dict with keys train/valid/test.
+
+    Scaffold splitting groups structurally similar molecules into the same split,
+    preventing the model from exploiting local structural memorisation across splits.
+
+    Params:
+        seed: int : random seed for reproducibility
+    Returns:
+        dict[str, pd.DataFrame] : each DataFrame has columns Drug_ID, Drug, Y
+    """
     data = ADME(name="Lipophilicity_AstraZeneca")
     split = data.get_split(method="scaffold", seed=seed)
     return split

--- a/src/explain.py
+++ b/src/explain.py
@@ -4,9 +4,8 @@ import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from captum.attr import LayerIntegratedGradients
+from captum.attr import IntegratedGradients
 from rdkit import Chem
-from rdkit.Chem import Draw
 from rdkit.Chem.Draw import rdMolDraw2D
 
 from src.gnn_model import LipophilicityGNN
@@ -27,7 +26,7 @@ def _make_single_loader(smiles: str, lm_emb: np.ndarray):
 
     dataset = build_chemprop_dataset(
         smiles=[smiles],
-        targets=np.array([0.0]),  # placeholder target
+        targets=np.array([0.0]),
         lm_embeddings=lm_emb[np.newaxis],
     )
     return build_dataloader(dataset, batch_size=1, shuffle=False)
@@ -35,24 +34,23 @@ def _make_single_loader(smiles: str, lm_emb: np.ndarray):
 
 class AtomAttributionExplainer:
     """
-    Computes per-atom attribution scores using Captum LayerIntegratedGradients.
+    Computes per-atom attribution scores using Captum IntegratedGradients.
 
-    The target layer is the final output projection of the chemprop MPNN
-    (backbone.mp.W_o), which produces per-atom hidden states after all message
-    passing is complete. IG integrates gradients from a zero-activation baseline
-    to the real activation, giving each atom a signed importance score that
-    reflects its marginal contribution to the predicted logD.
+    IG is applied to the atom feature matrix (bmg.V) with a zero-vector baseline
+    representing an absent atom. At each integration step, bmg.V is replaced with
+    the alpha-scaled atom features so gradients flow through the full message-passing
+    network. Scores are the L2 norm of the attribution tensor over the feature
+    dimension, giving one non-negative scalar per heavy atom.
 
-    Note on layer name: W_o is the assumed attribute name for the final linear
-    projection in chemprop v2's BondMessagePassing. Verify with
-    `list(model.backbone.mp.named_modules())` if attribution fails.
+    This approach avoids the BatchMolGraph-incompatibility of LayerIntegratedGradients,
+    which requires Captum to create baselines from non-tensor inputs.
     """
 
     def __init__(
         self, model: LipophilicityGNN, device: torch.device | None = None
     ) -> None:
         """
-        Attach IntegratedGradients to the MPNN's final atom projection.
+        Initialise IntegratedGradients targeting the atom feature matrix.
 
         Params:
             model: LipophilicityGNN : trained model (must be in eval mode)
@@ -64,10 +62,12 @@ class AtomAttributionExplainer:
         self.device = device or next(model.parameters()).device
         self.model.eval()
 
-        def _forward(bmg, V_d):
-            return self.model(bmg, V_d).squeeze(-1)
+        def _fwd(V: torch.Tensor, bmg, X_d: torch.Tensor | None) -> torch.Tensor:
+            # Patch atom features so IG can vary them along the integration path.
+            bmg.V = V
+            return model(bmg, X_d).squeeze(-1)
 
-        self.lig = LayerIntegratedGradients(_forward, model.backbone.mp.W_o)
+        self.ig = IntegratedGradients(_fwd)
 
     def explain(
         self,
@@ -78,8 +78,9 @@ class AtomAttributionExplainer:
         """
         Return per-atom attribution scores for a single molecule.
 
-        Attribution is the L2 norm of the IG tensor over the hidden-state
-        dimension, giving one non-negative scalar per heavy atom.
+        IG integrates the gradient of the model output w.r.t. the atom feature
+        matrix from a zero baseline to the actual features. Scores are the L2
+        norm over the feature dimension, giving one non-negative value per atom.
 
         Params:
             smiles: str : SMILES string of the molecule to explain
@@ -90,16 +91,25 @@ class AtomAttributionExplainer:
         """
         loader = _make_single_loader(smiles, lm_emb)
         batch = next(iter(loader))
-        bmg = batch.bmg.to(self.device)
+        batch.bmg.to(self.device)  # in-place; returns None
+        bmg = batch.bmg
         X_d = batch.X_d.to(self.device) if batch.X_d is not None else None
 
-        attr = self.lig.attribute(
-            inputs=(bmg, X_d),
+        V = bmg.V.detach().clone()
+        attr = self.ig.attribute(
+            inputs=V,
+            baselines=torch.zeros_like(V),
+            additional_forward_args=(bmg, X_d),
             n_steps=n_steps,
-            attribute_to_layer_input=False,  # attribute to W_o output
+            # One alpha step per forward call so bmg.batch (fixed, single molecule)
+            # stays consistent with the atom count in V.
+            internal_batch_size=1,
         )
-        # attr: (n_atoms, d_h) — aggregate over feature dim
-        scores = torch.norm(attr, dim=-1).detach().cpu().numpy().astype(np.float32)
+        # Sum over the feature dimension to preserve sign:
+        # positive = atom features push logD up (hydrophobic, red)
+        # negative = atom features pull logD down (hydrophilic, blue)
+        # norm() would discard the sign and make everything non-negative.
+        scores = attr.sum(dim=-1).detach().cpu().numpy().astype(np.float32)
         return scores
 
 
@@ -130,17 +140,21 @@ def plot_atom_contributions(
     if mol is None:
         raise ValueError(f"Invalid SMILES: {smiles!r}")
 
-    # Normalise scores symmetrically around zero so red/blue balance makes sense.
     max_abs = float(np.abs(scores).max()) or 1.0
     norm_scores = scores / max_abs  # in [-1, 1]
 
-    cmap = plt.cm.RdBu_r  # red = positive, blue = negative
+    cmap = plt.get_cmap("RdBu_r")  # red = positive, blue = negative
     atom_colours: dict[int, tuple] = {}
+    alpha = 0.5
     for i, s in enumerate(norm_scores):
-        rgba = cmap((s + 1.0) / 2.0)  # map [-1,1] → [0,1]
-        atom_colours[i] = rgba[:3]
+        r, g, b, _ = cmap((s + 1.0) / 2.0)  # map [-1,1] → [0,1]
+        atom_colours[i] = (r, g, b, alpha)
 
-    drawer = rdMolDraw2D.MolDraw2DSVG(*size)
+    import io
+
+    from PIL import Image
+
+    drawer = rdMolDraw2D.MolDraw2DCairo(*size)
     drawer.drawOptions().addAtomIndices = False
     rdMolDraw2D.PrepareAndDrawMolecule(
         drawer,
@@ -151,33 +165,7 @@ def plot_atom_contributions(
         highlightBondColors={},
     )
     drawer.FinishDrawing()
-    svg = drawer.GetDrawingText()
-
-    # Render SVG into a matplotlib figure via a temporary PNG round-trip.
-    import io
-
-    from rdkit.Chem.Draw import MolToImage
-
-    pillow_colours = {
-        i: tuple(int(c * 255) for c in atom_colours[i]) for i in atom_colours
-    }
-    img = MolToImage(
-        mol,
-        size=size,
-        highlightAtoms=list(range(mol.GetNumAtoms())),
-        highlightColor=None,
-    )
-    # Fall back to SVG-based rendering for proper per-atom colouring.
-    try:
-        import cairosvg
-
-        png_bytes = cairosvg.svg2png(bytestring=svg.encode())
-        from PIL import Image
-
-        img = Image.open(io.BytesIO(png_bytes))
-    except ImportError:
-        # cairosvg not available; use simple uniform highlight as fallback.
-        pass
+    img = Image.open(io.BytesIO(drawer.GetDrawingText()))
 
     fig, ax = plt.subplots(figsize=(size[0] / 100, size[1] / 100))
     ax.imshow(img)
@@ -185,7 +173,6 @@ def plot_atom_contributions(
     if title:
         ax.set_title(title, fontsize=10)
 
-    # Colourbar
     sm = plt.cm.ScalarMappable(
         cmap=cmap, norm=mcolors.Normalize(vmin=-max_abs, vmax=max_abs)
     )

--- a/src/explain.py
+++ b/src/explain.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from captum.attr import LayerIntegratedGradients
+from rdkit import Chem
+from rdkit.Chem import Draw
+from rdkit.Chem.Draw import rdMolDraw2D
+
+from src.gnn_model import LipophilicityGNN
+from src.graph_data import build_chemprop_dataset
+
+
+def _make_single_loader(smiles: str, lm_emb: np.ndarray):
+    """
+    Build a single-molecule chemprop DataLoader for inference and attribution.
+
+    Params:
+        smiles: str : SMILES string for the molecule
+        lm_emb: np.ndarray : ChemBERTa [CLS] embedding, shape (768,)
+    Returns:
+        DataLoader : chemprop loader yielding one batch of size 1
+    """
+    from chemprop.data import build_dataloader
+
+    dataset = build_chemprop_dataset(
+        smiles=[smiles],
+        targets=np.array([0.0]),  # placeholder target
+        lm_embeddings=lm_emb[np.newaxis],
+    )
+    return build_dataloader(dataset, batch_size=1, shuffle=False)
+
+
+class AtomAttributionExplainer:
+    """
+    Computes per-atom attribution scores using Captum LayerIntegratedGradients.
+
+    The target layer is the final output projection of the chemprop MPNN
+    (backbone.mp.W_o), which produces per-atom hidden states after all message
+    passing is complete. IG integrates gradients from a zero-activation baseline
+    to the real activation, giving each atom a signed importance score that
+    reflects its marginal contribution to the predicted logD.
+
+    Note on layer name: W_o is the assumed attribute name for the final linear
+    projection in chemprop v2's BondMessagePassing. Verify with
+    `list(model.backbone.mp.named_modules())` if attribution fails.
+    """
+
+    def __init__(
+        self, model: LipophilicityGNN, device: torch.device | None = None
+    ) -> None:
+        """
+        Attach IntegratedGradients to the MPNN's final atom projection.
+
+        Params:
+            model: LipophilicityGNN : trained model (must be in eval mode)
+            device: torch.device | None : inference device; defaults to model's device
+        Returns:
+            None
+        """
+        self.model = model
+        self.device = device or next(model.parameters()).device
+        self.model.eval()
+
+        def _forward(bmg, V_d):
+            return self.model(bmg, V_d).squeeze(-1)
+
+        self.lig = LayerIntegratedGradients(_forward, model.backbone.mp.W_o)
+
+    def explain(
+        self,
+        smiles: str,
+        lm_emb: np.ndarray,
+        n_steps: int = 50,
+    ) -> np.ndarray:
+        """
+        Return per-atom attribution scores for a single molecule.
+
+        Attribution is the L2 norm of the IG tensor over the hidden-state
+        dimension, giving one non-negative scalar per heavy atom.
+
+        Params:
+            smiles: str : SMILES string of the molecule to explain
+            lm_emb: np.ndarray : ChemBERTa [CLS] embedding, shape (768,)
+            n_steps: int : number of integration steps (higher = more accurate)
+        Returns:
+            np.ndarray : per-atom scores, shape (n_heavy_atoms,), float32
+        """
+        loader = _make_single_loader(smiles, lm_emb)
+        batch = next(iter(loader))
+        bmg = batch.bmg.to(self.device)
+        X_d = batch.X_d.to(self.device) if batch.X_d is not None else None
+
+        attr = self.lig.attribute(
+            inputs=(bmg, X_d),
+            n_steps=n_steps,
+            attribute_to_layer_input=False,  # attribute to W_o output
+        )
+        # attr: (n_atoms, d_h) — aggregate over feature dim
+        scores = torch.norm(attr, dim=-1).detach().cpu().numpy().astype(np.float32)
+        return scores
+
+
+def plot_atom_contributions(
+    smiles: str,
+    scores: np.ndarray,
+    title: str = "",
+    size: tuple[int, int] = (400, 300),
+) -> plt.Figure:
+    """
+    Draw a 2D molecule coloured by per-atom attribution scores.
+
+    Atoms with positive logD contribution (hydrophobic) are coloured red;
+    atoms with negative contribution (hydrophilic) are coloured blue.
+    Scores are normalised to [-1, 1] across the molecule before mapping to
+    colour, so the colour scale is consistent within one molecule but not
+    comparable across different molecules.
+
+    Params:
+        smiles: str : SMILES string of the molecule
+        scores: np.ndarray : per-atom attribution scores, shape (n_heavy_atoms,)
+        title: str : optional figure title
+        size: tuple[int, int] : pixel dimensions for the structure image
+    Returns:
+        plt.Figure : matplotlib figure containing the coloured structure
+    """
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"Invalid SMILES: {smiles!r}")
+
+    # Normalise scores symmetrically around zero so red/blue balance makes sense.
+    max_abs = float(np.abs(scores).max()) or 1.0
+    norm_scores = scores / max_abs  # in [-1, 1]
+
+    cmap = plt.cm.RdBu_r  # red = positive, blue = negative
+    atom_colours: dict[int, tuple] = {}
+    for i, s in enumerate(norm_scores):
+        rgba = cmap((s + 1.0) / 2.0)  # map [-1,1] → [0,1]
+        atom_colours[i] = rgba[:3]
+
+    drawer = rdMolDraw2D.MolDraw2DSVG(*size)
+    drawer.drawOptions().addAtomIndices = False
+    rdMolDraw2D.PrepareAndDrawMolecule(
+        drawer,
+        mol,
+        highlightAtoms=list(range(mol.GetNumAtoms())),
+        highlightAtomColors=atom_colours,
+        highlightBonds=[],
+        highlightBondColors={},
+    )
+    drawer.FinishDrawing()
+    svg = drawer.GetDrawingText()
+
+    # Render SVG into a matplotlib figure via a temporary PNG round-trip.
+    import io
+
+    from rdkit.Chem.Draw import MolToImage
+
+    pillow_colours = {
+        i: tuple(int(c * 255) for c in atom_colours[i]) for i in atom_colours
+    }
+    img = MolToImage(
+        mol,
+        size=size,
+        highlightAtoms=list(range(mol.GetNumAtoms())),
+        highlightColor=None,
+    )
+    # Fall back to SVG-based rendering for proper per-atom colouring.
+    try:
+        import cairosvg
+
+        png_bytes = cairosvg.svg2png(bytestring=svg.encode())
+        from PIL import Image
+
+        img = Image.open(io.BytesIO(png_bytes))
+    except ImportError:
+        # cairosvg not available; use simple uniform highlight as fallback.
+        pass
+
+    fig, ax = plt.subplots(figsize=(size[0] / 100, size[1] / 100))
+    ax.imshow(img)
+    ax.axis("off")
+    if title:
+        ax.set_title(title, fontsize=10)
+
+    # Colourbar
+    sm = plt.cm.ScalarMappable(
+        cmap=cmap, norm=mcolors.Normalize(vmin=-max_abs, vmax=max_abs)
+    )
+    sm.set_array([])
+    cbar = fig.colorbar(sm, ax=ax, orientation="vertical", fraction=0.046, pad=0.04)
+    cbar.set_label("Attribution score", fontsize=8)
+    plt.tight_layout()
+    return fig

--- a/src/features.py
+++ b/src/features.py
@@ -10,9 +10,14 @@ from src.utils import get_mol_fgs
 
 
 def get_mol_descriptors(mol, missingVal=None) -> dict:
-    """Calculate the full list of RDKit descriptors for a molecule.
+    """
+    Compute the full list of RDKit descriptors for a single molecule.
 
-    missingVal is used if a descriptor cannot be calculated.
+    Params:
+        mol: Chem.Mol : RDKit molecule object
+        missingVal: any : value to use when a descriptor raises an exception
+    Returns:
+        dict : descriptor name → computed value (or missingVal on failure)
     """
     res = {}
     for nm, fn in Descriptors._descList:
@@ -26,10 +31,16 @@ def get_mol_descriptors(mol, missingVal=None) -> dict:
 
 
 def smiles_to_descriptors(smiles: pd.Series) -> pd.DataFrame:
-    """Compute RDKit descriptors for a Series of SMILES strings.
+    """
+    Compute RDKit descriptors for a Series of SMILES strings.
 
-    Invalid SMILES produce rows of NaN. Returns a DataFrame aligned to
-    the input index with one column per RDKit descriptor.
+    Invalid SMILES produce a row of NaN rather than being dropped, preserving
+    index alignment with the input for safe downstream merging.
+
+    Params:
+        smiles: pd.Series : SMILES strings, any index
+    Returns:
+        pd.DataFrame : shape (n, n_descriptors), index matches input, one column per RDKit descriptor
     """
     descriptor_names = [nm for nm, _ in Descriptors._descList]
 
@@ -45,10 +56,17 @@ def smiles_to_descriptors(smiles: pd.Series) -> pd.DataFrame:
 
 
 def smiles_to_fgs(smiles: pd.Series) -> pd.DataFrame:
-    """Compute binary functional group presence for a Series of SMILES strings.
+    """
+    Compute binary functional group presence for a Series of SMILES strings.
 
-    Invalid SMILES produce rows of NaN. Returns a DataFrame aligned to the
-    input index with one column per functional group (1 = present, 0 = absent).
+    Invalid SMILES produce a row of NaN rather than being dropped, preserving
+    index alignment with the input. Functional group definitions come from
+    RDKit's built-in hierarchy, flattened to a single level.
+
+    Params:
+        smiles: pd.Series : SMILES strings, any index
+    Returns:
+        pd.DataFrame : shape (n, n_fgs), index matches input, values are 0 or 1
     """
     records = []
     for smi in tqdm(smiles, desc="Computing functional groups"):

--- a/src/gnn_model.py
+++ b/src/gnn_model.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from chemprop.models import MPNN
+from chemprop.nn import BondMessagePassing
+
+
+class ChempropBackbone(nn.Module):
+    """
+    Wraps chemprop's BondMessagePassing to expose per-atom hidden states.
+
+    By default initialises a fresh BondMessagePassing with chemprop's standard
+    MultiHot atom (72-dim) and bond (14-dim) featurisers. If a checkpoint path
+    is supplied the full MPNN is loaded and only the message-passing submodule
+    is retained; the chemprop aggregation and FFN head are discarded because we
+    replace them with AttentionPooling and FusionMLP.
+    """
+
+    # Feature dims that match chemprop v2's default MultiHot featurisers.
+    _D_V = 72
+    _D_E = 14
+
+    def __init__(
+        self,
+        d_h: int = 300,
+        depth: int = 3,
+        dropout: float = 0.0,
+        checkpoint_path: str | None = None,
+    ) -> None:
+        """
+        Initialise the backbone.
+
+        Params:
+            d_h: int : hidden dimension (ignored when loading from checkpoint)
+            depth: int : number of message-passing steps (ignored from checkpoint)
+            dropout: float : dropout probability inside the MPNN
+            checkpoint_path: str | None : path to a chemprop v2 .ckpt file
+        Returns:
+            None
+        """
+        super().__init__()
+        if checkpoint_path is not None:
+            full_model = MPNN.load_from_checkpoint(checkpoint_path)
+            self.mp = full_model.message_passing
+        else:
+            self.mp = BondMessagePassing(
+                d_v=self._D_V,
+                d_e=self._D_E,
+                d_h=d_h,
+                depth=depth,
+                dropout=dropout,
+            )
+        # Infer actual hidden dim from the final linear projection weight.
+        # BondMessagePassing names this layer W_o; adjust if the chemprop
+        # version in use differs.
+        self.d_h: int = self.mp.W_o.out_features
+
+    def forward(self, bmg) -> torch.Tensor:
+        """
+        Run directed message passing and return per-atom hidden states.
+
+        Params:
+            bmg: BatchMolGraph : batched molecular graph from chemprop DataLoader
+        Returns:
+            torch.Tensor : per-atom hidden states, shape (n_atoms_total, d_h)
+        """
+        return self.mp(bmg)
+
+
+class AttentionPooling(nn.Module):
+    """
+    Sigmoid-gated attention pooling from atom hidden states to a molecule vector.
+
+    Uses sigmoid rather than softmax so multiple atoms can simultaneously receive
+    high weight; this avoids zero-sum competition between atoms and produces
+    cleaner per-atom attribution signals when Captum IntegratedGradients is applied
+    downstream.
+    """
+
+    def __init__(self, d_h: int) -> None:
+        """
+        Initialise the attention gate.
+
+        Params:
+            d_h: int : atom hidden-state dimension
+        Returns:
+            None
+        """
+        super().__init__()
+        self.gate = nn.Linear(d_h, 1)
+
+    def forward(self, H: torch.Tensor, batch: torch.Tensor) -> torch.Tensor:
+        """
+        Pool atom representations to molecule representations.
+
+        Params:
+            H: torch.Tensor : atom hidden states, shape (n_atoms_total, d_h)
+            batch: torch.Tensor : molecule index per atom, shape (n_atoms_total,), int64
+        Returns:
+            torch.Tensor : molecule embeddings, shape (n_mols, d_h)
+        """
+        scores = torch.sigmoid(self.gate(H))  # (n_atoms, 1)
+        weighted = scores * H  # (n_atoms, d_h)
+        n_mols = int(batch.max().item()) + 1
+        out = torch.zeros(n_mols, H.size(-1), device=H.device, dtype=H.dtype)
+        out.scatter_add_(0, batch.unsqueeze(-1).expand_as(weighted), weighted)
+        return out
+
+
+class FusionMLP(nn.Module):
+    """MLP that fuses the graph embedding with the ChemBERTa [CLS] embedding."""
+
+    def __init__(self, d_in: int, d_hidden: int = 256, dropout: float = 0.1) -> None:
+        """
+        Initialise the fusion head.
+
+        Params:
+            d_in: int : concatenated input dimension (d_graph + d_lm)
+            d_hidden: int : intermediate hidden dimension
+            dropout: float : dropout probability
+        Returns:
+            None
+        """
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.LayerNorm(d_in),
+            nn.Linear(d_in, d_hidden),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(d_hidden, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Predict logD from fused molecular embedding.
+
+        Params:
+            x: torch.Tensor : fused embedding, shape (n_mols, d_in)
+        Returns:
+            torch.Tensor : predictions, shape (n_mols, 1)
+        """
+        return self.net(x)
+
+
+class LipophilicityGNN(nn.Module):
+    """
+    Full model: chemprop MPNN backbone + attention pooling + ChemBERTa fusion.
+
+    Architecture (Option A):
+      1. ChempropBackbone  : SMILES graph -> per-atom hidden states  h_atoms
+      2. AttentionPooling  : h_atoms -> graph embedding              h_graph
+      3. Concatenation     : [h_graph ; V_d]                        h_fused
+      4. FusionMLP         : h_fused -> predicted logD scalar
+    """
+
+    def __init__(
+        self,
+        d_h: int = 300,
+        d_lm: int = 768,
+        d_hidden: int = 256,
+        depth: int = 3,
+        dropout: float = 0.0,
+        checkpoint_path: str | None = None,
+    ) -> None:
+        """
+        Initialise all submodules.
+
+        Params:
+            d_h: int : MPNN hidden dimension
+            d_lm: int : ChemBERTa embedding dimension
+            d_hidden: int : FusionMLP hidden dimension
+            depth: int : number of message-passing steps
+            dropout: float : dropout in MPNN and FusionMLP
+            checkpoint_path: str | None : optional chemprop checkpoint to load
+        Returns:
+            None
+        """
+        super().__init__()
+        self.backbone = ChempropBackbone(
+            d_h=d_h, depth=depth, dropout=dropout, checkpoint_path=checkpoint_path
+        )
+        self.pool = AttentionPooling(self.backbone.d_h)
+        self.fusion = FusionMLP(
+            d_in=self.backbone.d_h + d_lm,
+            d_hidden=d_hidden,
+            dropout=dropout,
+        )
+
+    def forward(self, bmg, V_d: torch.Tensor) -> torch.Tensor:
+        """
+        Predict logD for a batch of molecules.
+
+        Params:
+            bmg: BatchMolGraph : batched molecular graph from chemprop DataLoader
+            V_d: torch.Tensor : ChemBERTa [CLS] embeddings, shape (n_mols, d_lm)
+        Returns:
+            torch.Tensor : predicted logD values, shape (n_mols, 1)
+        """
+        H = self.backbone(bmg)  # (n_atoms_total, d_h)
+        h_graph = self.pool(H, bmg.batch)  # (n_mols, d_h)
+        h_fused = torch.cat([h_graph, V_d], dim=-1)  # (n_mols, d_h + d_lm)
+        return self.fusion(h_fused)  # (n_mols, 1)

--- a/src/graph_data.py
+++ b/src/graph_data.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+from chemprop.data import MoleculeDatapoint, MoleculeDataset
+from transformers import AutoModel, AutoTokenizer
+
+_CHEMBERTA_MODEL = "seyonec/ChemBERTa-zinc-base-v1"
+
+
+class ChemBertaEncoder(nn.Module):
+    """Frozen ChemBERTa encoder that extracts per-molecule [CLS] embeddings."""
+
+    def __init__(self, model_name: str = _CHEMBERTA_MODEL) -> None:
+        """
+        Load and permanently freeze ChemBERTa weights.
+
+        Params:
+            model_name: str : HuggingFace model identifier
+        Returns:
+            None
+        """
+        import transformers
+
+        super().__init__()
+        # Suppress the MISSING/UNEXPECTED weight report — expected when loading the
+        # base encoder from a masked-LM checkpoint without the LM head.
+        transformers.logging.set_verbosity_error()
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.bert = AutoModel.from_pretrained(model_name, use_safetensors=True)
+        transformers.logging.set_verbosity_warning()
+        for param in self.bert.parameters():
+            param.requires_grad = False
+        self.bert.eval()
+
+    @torch.no_grad()
+    def encode(self, smiles: list[str], batch_size: int = 64) -> np.ndarray:
+        """
+        Encode SMILES strings into [CLS] hidden-state vectors.
+
+        Params:
+            smiles: list[str] : SMILES strings to encode
+            batch_size: int : molecules per forward pass
+        Returns:
+            np.ndarray : float32 array of shape (n, 768)
+        """
+        device = next(self.bert.parameters()).device
+        chunks = []
+        for i in range(0, len(smiles), batch_size):
+            batch = smiles[i : i + batch_size]
+            inputs = self.tokenizer(
+                batch,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+                max_length=512,
+            )
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            outputs = self.bert(**inputs)
+            cls = outputs.last_hidden_state[:, 0, :].cpu().numpy()
+            chunks.append(cls)
+        return np.concatenate(chunks, axis=0).astype(np.float32)
+
+    def forward(self, smiles: list[str]) -> torch.Tensor:
+        """
+        Encode SMILES and return embeddings as a Tensor (nn.Module compatibility).
+
+        Params:
+            smiles: list[str] : SMILES strings to encode
+        Returns:
+            torch.Tensor : shape (n, 768)
+        """
+        return torch.from_numpy(self.encode(smiles))
+
+
+def build_chemprop_dataset(
+    smiles: pd.Series | list[str],
+    targets: np.ndarray,
+    lm_embeddings: np.ndarray,
+) -> MoleculeDataset:
+    """
+    Build a chemprop MoleculeDataset with ChemBERTa embeddings as extra descriptors.
+
+    Each datapoint stores the ChemBERTa [CLS] embedding in x_d, which the
+    chemprop DataLoader batches into a V_d tensor alongside the molecular graphs.
+    Embeddings are precomputed at construction time — safe because ChemBertaEncoder
+    is frozen throughout training.
+
+    Params:
+        smiles: pd.Series | list[str] : SMILES strings
+        targets: np.ndarray : regression targets, shape (n,)
+        lm_embeddings: np.ndarray : ChemBERTa [CLS] embeddings, shape (n, 768)
+    Returns:
+        MoleculeDataset : dataset ready for chemprop.data.build_dataloader
+    """
+    smiles_list = list(smiles)
+    datapoints = [
+        MoleculeDatapoint.from_smi(
+            smi,
+            y=np.array([float(y)], dtype=np.float32),
+            x_d=lm_emb.astype(np.float32),
+        )
+        for smi, y, lm_emb in zip(smiles_list, targets, lm_embeddings)
+    ]
+    return MoleculeDataset(datapoints)

--- a/src/train_gnn.py
+++ b/src/train_gnn.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import lightning as L
+import numpy as np
+import torch
+import torch.nn as nn
+from chemprop.data import build_dataloader
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+
+from src.data import get_splits
+from src.gnn_model import LipophilicityGNN
+from src.graph_data import ChemBertaEncoder, build_chemprop_dataset
+
+# ---------------------------------------------------------------------------
+# Metric helper (mirrors evaluate() in the baseline models branch)
+# ---------------------------------------------------------------------------
+
+
+def evaluate_gnn(
+    model: LipophilicityGNN,
+    loader,
+    device: torch.device,
+) -> dict[str, float]:
+    """
+    Compute RMSE, MAE, and R² for a fitted GNN on a chemprop DataLoader.
+
+    Params:
+        model: LipophilicityGNN : fitted model in eval mode
+        loader: DataLoader : chemprop DataLoader yielding TrainingBatch tuples
+        device: torch.device : device to run inference on
+    Returns:
+        dict[str, float] : keys 'rmse', 'mae', 'r2'
+    """
+    model.eval()
+    preds, targets = [], []
+    with torch.no_grad():
+        for batch in loader:
+            bmg = batch.bmg.to(device)
+            X_d = batch.X_d.to(device) if batch.X_d is not None else None
+            Y = batch.Y.squeeze(-1)
+            out = model(bmg, X_d).squeeze(-1).cpu()
+            preds.append(out.numpy())
+            targets.append(Y.numpy())
+    y_pred = np.concatenate(preds)
+    y_true = np.concatenate(targets)
+    return {
+        "rmse": float(mean_squared_error(y_true, y_pred) ** 0.5),
+        "mae": float(mean_absolute_error(y_true, y_pred)),
+        "r2": float(r2_score(y_true, y_pred)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lightning module
+# ---------------------------------------------------------------------------
+
+
+class GNNLitModule(L.LightningModule):
+    """PyTorch Lightning wrapper for LipophilicityGNN."""
+
+    def __init__(
+        self,
+        model: LipophilicityGNN,
+        lr: float = 1e-3,
+        weight_decay: float = 1e-4,
+        t_max: int = 100,
+    ) -> None:
+        """
+        Wrap a LipophilicityGNN for Lightning training.
+
+        Params:
+            model: LipophilicityGNN : the GNN model to train
+            lr: float : AdamW learning rate
+            weight_decay: float : AdamW weight decay
+            t_max: int : CosineAnnealingLR period in epochs
+        Returns:
+            None
+        """
+        super().__init__()
+        self.model = model
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.t_max = t_max
+        self.loss_fn = nn.MSELoss()
+
+    def _step(self, batch, split: str) -> torch.Tensor:
+        bmg = batch.bmg
+        X_d = batch.X_d
+        Y = batch.Y.float()
+        preds = self.model(bmg, X_d).squeeze(-1)
+        targets = Y.squeeze(-1)
+        loss = self.loss_fn(preds, targets)
+        mae = (preds - targets).abs().mean()
+        self.log(f"{split}_loss", loss, prog_bar=(split == "val"), batch_size=len(Y))
+        self.log(f"{split}_mae", mae, prog_bar=(split == "val"), batch_size=len(Y))
+        return loss
+
+    def training_step(self, batch: Any, batch_idx: int) -> torch.Tensor:
+        """
+        Compute MSE loss for a training batch.
+
+        Params:
+            batch: Any : chemprop TrainingBatch
+            batch_idx: int : batch index (unused)
+        Returns:
+            torch.Tensor : scalar MSE loss
+        """
+        return self._step(batch, "train")
+
+    def validation_step(self, batch: Any, batch_idx: int) -> None:
+        """
+        Log validation MAE and loss without returning a value.
+
+        Params:
+            batch: Any : chemprop TrainingBatch
+            batch_idx: int : batch index (unused)
+        Returns:
+            None
+        """
+        self._step(batch, "val")
+
+    def test_step(self, batch: Any, batch_idx: int) -> None:
+        """
+        Log test MAE and loss without returning a value.
+
+        Params:
+            batch: Any : chemprop TrainingBatch
+            batch_idx: int : batch index (unused)
+        Returns:
+            None
+        """
+        self._step(batch, "test")
+
+    def configure_optimizers(self) -> dict:
+        """
+        Return AdamW optimizer with cosine annealing LR scheduler.
+
+        Params:
+            None
+        Returns:
+            dict : Lightning optimizer/scheduler config
+        """
+        opt = torch.optim.AdamW(
+            self.model.parameters(), lr=self.lr, weight_decay=self.weight_decay
+        )
+        sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=self.t_max)
+        return {
+            "optimizer": opt,
+            "lr_scheduler": {"scheduler": sched, "interval": "epoch"},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Training entry point
+# ---------------------------------------------------------------------------
+
+
+def train_gnn(
+    config: dict | None = None,
+    checkpoint_dir: str | Path = "checkpoints",
+) -> tuple[LipophilicityGNN, dict[str, dict[str, float]]]:
+    """
+    Full training pipeline: load data, encode ChemBERTa, train GNN, return metrics.
+
+    Params:
+        config: dict | None : hyperparameters; missing keys fall back to defaults
+        checkpoint_dir: str | Path : directory for Lightning checkpoints
+    Returns:
+        tuple[LipophilicityGNN, dict] : best model and metrics per split
+    """
+    cfg = {
+        "d_h": 300,
+        "d_lm": 768,
+        "d_hidden": 256,
+        "depth": 3,
+        "dropout": 0.0,
+        "lr": 1e-3,
+        "weight_decay": 1e-4,
+        "batch_size": 64,
+        "max_epochs": 100,
+        "patience": 20,
+        "checkpoint_path": None,
+        "seed": 42,
+    }
+    if config:
+        cfg.update(config)
+
+    L.seed_everything(cfg["seed"], workers=True)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ckpt_dir = Path(checkpoint_dir)
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Data ---
+    splits = get_splits(seed=cfg["seed"])
+    encoder = ChemBertaEncoder().to(device)
+
+    lm_embs = {
+        name: encoder.encode(split["Drug"].tolist()) for name, split in splits.items()
+    }
+    datasets = {
+        name: build_chemprop_dataset(
+            splits[name]["Drug"],
+            splits[name]["Y"].values,
+            lm_embs[name],
+        )
+        for name in ("train", "valid", "test")
+    }
+    loaders = {
+        "train": build_dataloader(
+            datasets["train"], batch_size=cfg["batch_size"], shuffle=True
+        ),
+        "valid": build_dataloader(
+            datasets["valid"], batch_size=cfg["batch_size"], shuffle=False
+        ),
+        "test": build_dataloader(
+            datasets["test"], batch_size=cfg["batch_size"], shuffle=False
+        ),
+    }
+
+    # --- Model ---
+    model = LipophilicityGNN(
+        d_h=cfg["d_h"],
+        d_lm=cfg["d_lm"],
+        d_hidden=cfg["d_hidden"],
+        depth=cfg["depth"],
+        dropout=cfg["dropout"],
+        checkpoint_path=cfg["checkpoint_path"],
+    )
+    lit = GNNLitModule(
+        model, lr=cfg["lr"], weight_decay=cfg["weight_decay"], t_max=cfg["max_epochs"]
+    )
+
+    # --- Callbacks ---
+    early_stop = L.pytorch.callbacks.EarlyStopping(
+        monitor="val_mae", patience=cfg["patience"], mode="min"
+    )
+    ckpt_cb = L.pytorch.callbacks.ModelCheckpoint(
+        dirpath=ckpt_dir,
+        filename="gnn-best-{epoch:03d}-{val_mae:.4f}",
+        monitor="val_mae",
+        mode="min",
+        save_top_k=1,
+    )
+
+    trainer = L.Trainer(
+        max_epochs=cfg["max_epochs"],
+        accelerator="auto",
+        callbacks=[early_stop, ckpt_cb],
+        gradient_clip_val=1.0,
+        log_every_n_steps=1,
+        enable_progress_bar=True,
+    )
+    trainer.fit(lit, loaders["train"], loaders["valid"])
+
+    # Load best weights back into the unwrapped model.
+    # Manually strip the "model." prefix that Lightning adds to nested module keys.
+    ckpt_state = torch.load(ckpt_cb.best_model_path, map_location=device)
+    model_state = {
+        k[len("model.") :]: v
+        for k, v in ckpt_state["state_dict"].items()
+        if k.startswith("model.")
+    }
+    model.load_state_dict(model_state)
+    best_model = model.to(device).eval()
+
+    metrics = {
+        split: evaluate_gnn(best_model, loaders[split], device)
+        for split in ("train", "valid", "test")
+    }
+    return best_model, metrics
+
+
+def load_checkpoint(
+    checkpoint_path: str | Path,
+    device: torch.device | None = None,
+    **model_kwargs,
+) -> LipophilicityGNN:
+    """
+    Restore a LipophilicityGNN from a Lightning checkpoint written by train_gnn.
+
+    Params:
+        checkpoint_path: str | Path : path to the .ckpt file
+        device: torch.device | None : target device; defaults to CUDA if available
+        **model_kwargs: passed to LipophilicityGNN.__init__ (must match training config)
+    Returns:
+        LipophilicityGNN : model in eval mode on the requested device
+    """
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = LipophilicityGNN(**model_kwargs)
+    ckpt_state = torch.load(checkpoint_path, map_location=device)
+    model_state = {
+        k[len("model.") :]: v
+        for k, v in ckpt_state["state_dict"].items()
+        if k.startswith("model.")
+    }
+    model.load_state_dict(model_state)
+    return model.to(device).eval()

--- a/src/train_gnn.py
+++ b/src/train_gnn.py
@@ -8,6 +8,9 @@ import numpy as np
 import torch
 import torch.nn as nn
 from chemprop.data import build_dataloader
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
+from lightning.pytorch.loggers import CSVLogger, WandbLogger
+from lightning.pytorch.utilities.types import OptimizerLRScheduler
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
 from src.data import get_splits
@@ -38,10 +41,10 @@ def evaluate_gnn(
     preds, targets = [], []
     with torch.no_grad():
         for batch in loader:
-            bmg = batch.bmg.to(device)
+            batch.bmg.to(device)  # in-place; BatchMolGraph.to() has no return value
             X_d = batch.X_d.to(device) if batch.X_d is not None else None
             Y = batch.Y.squeeze(-1)
-            out = model(bmg, X_d).squeeze(-1).cpu()
+            out = model(batch.bmg, X_d).squeeze(-1).cpu()
             preds.append(out.numpy())
             targets.append(Y.numpy())
     y_pred = np.concatenate(preds)
@@ -67,6 +70,7 @@ class GNNLitModule(L.LightningModule):
         lr: float = 1e-3,
         weight_decay: float = 1e-4,
         t_max: int = 100,
+        model_kwargs: dict | None = None,
     ) -> None:
         """
         Wrap a LipophilicityGNN for Lightning training.
@@ -76,6 +80,8 @@ class GNNLitModule(L.LightningModule):
             lr: float : AdamW learning rate
             weight_decay: float : AdamW weight decay
             t_max: int : CosineAnnealingLR period in epochs
+            model_kwargs: dict | None : LipophilicityGNN constructor kwargs, embedded
+                in the checkpoint so load_checkpoint can reconstruct the architecture
         Returns:
             None
         """
@@ -85,6 +91,18 @@ class GNNLitModule(L.LightningModule):
         self.weight_decay = weight_decay
         self.t_max = t_max
         self.loss_fn = nn.MSELoss()
+        self._model_kwargs: dict = model_kwargs or {}
+
+    def on_save_checkpoint(self, checkpoint: dict) -> None:
+        """
+        Embed model architecture kwargs in the checkpoint for self-contained loading.
+
+        Params:
+            checkpoint: dict : Lightning checkpoint dict (mutated in place)
+        Returns:
+            None
+        """
+        checkpoint["model_kwargs"] = self._model_kwargs
 
     def _step(self, batch, split: str) -> torch.Tensor:
         bmg = batch.bmg
@@ -98,43 +116,43 @@ class GNNLitModule(L.LightningModule):
         self.log(f"{split}_mae", mae, prog_bar=(split == "val"), batch_size=len(Y))
         return loss
 
-    def training_step(self, batch: Any, batch_idx: int) -> torch.Tensor:
+    def training_step(self, batch: Any, _batch_idx: int) -> torch.Tensor:
         """
         Compute MSE loss for a training batch.
 
         Params:
             batch: Any : chemprop TrainingBatch
-            batch_idx: int : batch index (unused)
+            _batch_idx: int : batch index (unused)
         Returns:
             torch.Tensor : scalar MSE loss
         """
         return self._step(batch, "train")
 
-    def validation_step(self, batch: Any, batch_idx: int) -> None:
+    def validation_step(self, batch: Any, _batch_idx: int) -> None:
         """
         Log validation MAE and loss without returning a value.
 
         Params:
             batch: Any : chemprop TrainingBatch
-            batch_idx: int : batch index (unused)
+            _batch_idx: int : batch index (unused)
         Returns:
             None
         """
         self._step(batch, "val")
 
-    def test_step(self, batch: Any, batch_idx: int) -> None:
+    def test_step(self, batch: Any, _batch_idx: int) -> None:
         """
         Log test MAE and loss without returning a value.
 
         Params:
             batch: Any : chemprop TrainingBatch
-            batch_idx: int : batch index (unused)
+            _batch_idx: int : batch index (unused)
         Returns:
             None
         """
         self._step(batch, "test")
 
-    def configure_optimizers(self) -> dict:
+    def configure_optimizers(self) -> OptimizerLRScheduler:
         """
         Return AdamW optimizer with cosine annealing LR scheduler.
 
@@ -203,7 +221,7 @@ def train_gnn(
     datasets = {
         name: build_chemprop_dataset(
             splits[name]["Drug"],
-            splits[name]["Y"].values,
+            np.asarray(splits[name]["Y"].values, dtype=np.float32),
             lm_embs[name],
         )
         for name in ("train", "valid", "test")
@@ -221,25 +239,40 @@ def train_gnn(
     }
 
     # --- Model ---
-    model = LipophilicityGNN(
-        d_h=cfg["d_h"],
-        d_lm=cfg["d_lm"],
-        d_hidden=cfg["d_hidden"],
-        depth=cfg["depth"],
-        dropout=cfg["dropout"],
-        checkpoint_path=cfg["checkpoint_path"],
-    )
+    model_kwargs = {
+        "d_h": cfg["d_h"],
+        "d_lm": cfg["d_lm"],
+        "d_hidden": cfg["d_hidden"],
+        "depth": cfg["depth"],
+        "dropout": cfg["dropout"],
+        "checkpoint_path": cfg["checkpoint_path"],
+    }
+    model = LipophilicityGNN(**model_kwargs)
     lit = GNNLitModule(
-        model, lr=cfg["lr"], weight_decay=cfg["weight_decay"], t_max=cfg["max_epochs"]
+        model,
+        lr=cfg["lr"],
+        weight_decay=cfg["weight_decay"],
+        t_max=cfg["max_epochs"],
+        model_kwargs=model_kwargs,
     )
 
-    # --- Callbacks ---
-    early_stop = L.pytorch.callbacks.EarlyStopping(
-        monitor="val_mae", patience=cfg["patience"], mode="min"
+    # --- Loggers ---
+    wandb_logger = WandbLogger(
+        project=cfg.get("wandb_project", "lipophilicity_pred"),
+        name=cfg.get("wandb_run_name", None),
+        config=cfg,  # logs all hyperparams including dropout, weight_decay, lr, etc.
     )
-    ckpt_cb = L.pytorch.callbacks.ModelCheckpoint(
+    csv_logger = CSVLogger(save_dir=str(ckpt_dir), name="logs")
+
+    # Trigger wandb lazy init now so we can read the (possibly auto-generated) run name
+    # and embed it in the checkpoint filename for traceability.
+    run_name = wandb_logger.experiment.name
+
+    # --- Callbacks ---
+    early_stop = EarlyStopping(monitor="val_mae", patience=cfg["patience"], mode="min")
+    ckpt_cb = ModelCheckpoint(
         dirpath=ckpt_dir,
-        filename="gnn-best-{epoch:03d}-{val_mae:.4f}",
+        filename=f"{run_name}-{{epoch:03d}}-{{val_mae:.4f}}",
         monitor="val_mae",
         mode="min",
         save_top_k=1,
@@ -252,8 +285,17 @@ def train_gnn(
         gradient_clip_val=1.0,
         log_every_n_steps=1,
         enable_progress_bar=True,
+        logger=[wandb_logger, csv_logger],
     )
     trainer.fit(lit, loaders["train"], loaders["valid"])
+
+    # Copy the per-epoch CSV to a stable path so the notebook can always find it.
+    import shutil
+
+    history_src = Path(csv_logger.log_dir) / "metrics.csv"
+    history_dst = ckpt_dir / "metrics_history.csv"
+    if history_src.exists():
+        shutil.copy(history_src, history_dst)
 
     # Load best weights back into the unwrapped model.
     # Manually strip the "model." prefix that Lightning adds to nested module keys.
@@ -281,21 +323,41 @@ def load_checkpoint(
     """
     Restore a LipophilicityGNN from a Lightning checkpoint written by train_gnn.
 
+    Architecture hyperparameters are read from the checkpoint's embedded
+    model_kwargs (written by GNNLitModule.on_save_checkpoint). Any kwargs
+    passed by the caller override the checkpoint values, which is useful for
+    the rare case of intentional architecture surgery but should not be needed
+    in normal use.
+
     Params:
         checkpoint_path: str | Path : path to the .ckpt file
         device: torch.device | None : target device; defaults to CUDA if available
-        **model_kwargs: passed to LipophilicityGNN.__init__ (must match training config)
+        **model_kwargs: override specific LipophilicityGNN constructor kwargs;
+            normally empty — the checkpoint is self-contained
     Returns:
         LipophilicityGNN : model in eval mode on the requested device
     """
     if device is None:
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model = LipophilicityGNN(**model_kwargs)
-    ckpt_state = torch.load(checkpoint_path, map_location=device)
+    ckpt_state = torch.load(checkpoint_path, map_location=device, weights_only=False)
     model_state = {
         k[len("model.") :]: v
         for k, v in ckpt_state["state_dict"].items()
         if k.startswith("model.")
     }
+
+    # Prefer kwargs embedded by on_save_checkpoint; fall back to inferring
+    # d_h / d_lm / d_hidden from weight shapes for checkpoints that pre-date
+    # this feature.  depth and dropout don't affect tensor shapes so they stay
+    # at their defaults when not stored.
+    if "model_kwargs" in ckpt_state:
+        kwargs = {**ckpt_state["model_kwargs"], **model_kwargs}
+    else:
+        d_h = model_state["backbone.mp.W_o.bias"].shape[0]
+        d_lm = model_state["fusion.net.0.weight"].shape[0] - d_h
+        d_hidden = model_state["fusion.net.1.bias"].shape[0]
+        kwargs = {"d_h": d_h, "d_lm": d_lm, "d_hidden": d_hidden, **model_kwargs}
+
+    model = LipophilicityGNN(**kwargs)
     model.load_state_dict(model_state)
     return model.to(device).eval()


### PR DESCRIPTION
## Summary/Issue

Closes #2. Implements the GNN + ChemBERTa lipophilicity predictor (Option A from
the architecture issue): a chemprop MPNN backbone encodes molecular graphs into
per-atom hidden states, a frozen ChemBERTa `[CLS]` vector provides global
molecular context, and a FusionMLP combines both for a single logD prediction.
Captum IntegratedGradients on the atom feature matrix produces signed per-atom
attribution scores for interpretability.

## Key Features + Dependencies

- Added `chemprop >= 2.0` and `captum >= 0.7` to `pixi.toml`.
- **`src/graph_data.py`** — `ChemBertaEncoder` (frozen `seyonec/ChemBERTa-zinc-base-v1`,
  `use_safetensors=True` required for torch 2.4 / CVE-2025-32434) and
  `build_chemprop_dataset` which attaches precomputed LM embeddings as `x_d`.
- **`src/gnn_model.py`** — `ChempropBackbone` (wraps `BondMessagePassing`, optional
  pretrained weight loading), `AttentionPooling` (sigmoid gate, not softmax, for
  multi-atom attribution compatibility), `FusionMLP`
  (`LayerNorm → Linear → ReLU → Dropout → Linear → 1`), `LipophilicityGNN`.
- **`src/train_gnn.py`** — `GNNLitModule` (AdamW + CosineAnnealingLR, early
  stopping on `val_mae`), `train_gnn` (end-to-end pipeline), `load_checkpoint`
  (self-contained: infers architecture from embedded `model_kwargs` or from weight
  shapes for legacy checkpoints). `WandbLogger` and `CSVLogger` wired in; wandb
  run name embedded in checkpoint filename for traceability.
- **`src/explain.py`** — `AtomAttributionExplainer` uses Captum `IntegratedGradients`
  on `bmg.V` (atom feature matrix) with `internal_batch_size=1` to avoid
  `BatchMolGraph` incompatibility with Captum's baseline handling. Scores are
  summed (not L2-normed) over the feature dimension to preserve sign.
  `plot_atom_contributions` renders via `MolDraw2DCairo` with RGBA highlights
  (0.5 alpha) for atom-type legibility.
- **`scripts/train_gnn.py`** — CLI with `--config` YAML, all hyperparameter flags,
  and `--wandb-project` / `--wandb-run-name`.
- **`notebooks/03_gnn_model.py`** — Marimo dashboard: checkpoint loader, data
  summary, training curves (rolling mean overlay), metrics table, parity plot,
  atom attribution gallery (6 molecules, low/mid/high logD), two-direction
  component ablation (zero `h_lm` and zero `h_graph` via forward hook).
- **`notebooks/README.md`**, **`src/README.md`**, **`scripts/README.md`** — added
  per the project README policy.
- Removed `src/models.py` and `src/preprocessing.py` (superseded by the new
  modular layout).

## Tests/Test Steps

- [ ] `pixi run python -c "import chemprop, captum; print('deps ok')"`
- [ ] `pixi run train-gnn --max-epochs 3` completes without error; checkpoint
  appears in `checkpoints/` named with the wandb run name.
- [ ] `load_checkpoint` on that checkpoint returns a model with the correct
  `d_h` / `d_hidden` without passing any kwargs.
- [ ] `pixi run notebook-gnn` opens without error; parity plot and attribution
  gallery render with coloured atoms (red/blue, not all one colour).
- [ ] Component ablation table shows three rows per split; `h_graph=0` and
  `h_lm=0` conditions both degrade performance relative to the full model.
- [ ] `pixi run train-gnn --dropout 0.2 --weight-decay 1e-3 --d-h 150 --d-hidden 128`
  trains and the resulting checkpoint loads correctly via `load_checkpoint`.

## Story

The main design choices and gotchas worth recording:

- `BatchMolGraph.to(device)` is in-place and returns `None` — every inference
  loop must call it for its side-effect, then use `batch.bmg` directly. This
  caused a late-training crash before it was caught.
- Captum's `LayerIntegratedGradients` cannot handle non-tensor inputs in `inputs`;
  the fix was to switch to plain `IntegratedGradients` on `bmg.V` with
  `additional_forward_args=(bmg, X_d)` and `internal_batch_size=1` (Captum
  otherwise concatenates all alpha steps into one batch, blowing up `bmg.batch`
  size mismatch).
- Attribution scores must use `.sum(dim=-1)` not `.norm(dim=-1)` — L2 norm
  discards sign, making all atoms appear red on the RdBu colormap.
- `MolDraw2DCairo` (in the conda rdkit package) renders per-atom RGBA highlights
  directly to PNG, removing the cairosvg dependency and the broken fallback path
  that had been silently drawing uncoloured structures.

## Related Issues / Branches

- Upstream: `1-implement-baseline-ml-models` (Lasso / RF baselines).
- Downstream: `3-stratified-scaffold-split` (planned — replace TDC scaffold
  split with a stratified Murcko split; `get_splits()` API unchanged).

## Other Notes

- The component ablation (zeroing `h_lm` or `h_graph` at inference time) should
  be interpreted cautiously — it creates a distribution shift for the jointly
  trained model. Definitive component importance requires training dedicated
  ablation models from scratch; flagged in the notebook with a callout.
- Overfitting was observed (train RMSE ≈ 0.45, val ≈ 0.65 on the current run).
  Regularisation experiments (`--dropout 0.2 --weight-decay 1e-3`) are in
  progress; this is tracked in W&B.