### PR TITLE
new splitting code + figs

### DIFF
--- a/notebooks/01_descriptors.py
+++ b/notebooks/01_descriptors.py
@@ -8,7 +8,9 @@ app = marimo.App(width="medium")
 def _():
     import marimo as mo
 
-    return (mo,)
+    from src.plot_utils import save_fig
+
+    return mo, save_fig
 
 
 @app.cell
@@ -60,7 +62,7 @@ def _(desc_df, mo):
 
 
 @app.cell
-def _(desc_df, df):
+def _(desc_df, df, save_fig):
     import matplotlib.pyplot as plt
 
     def _():
@@ -81,6 +83,7 @@ def _(desc_df, df):
         axes[1].set_title("Descriptor missingness")
 
         plt.tight_layout()
+        save_fig(fig, "01_target_distribution")
         return fig
 
     _()
@@ -88,7 +91,7 @@ def _(desc_df, df):
 
 
 @app.cell
-def _(desc_df, mo):
+def _(desc_df, mo, save_fig):
     def _():
         import matplotlib.pyplot as plt
         import numpy as np
@@ -116,6 +119,7 @@ def _(desc_df, mo):
         ax.set_title("Per-descriptor variance distribution")
         ax.legend()
         plt.tight_layout()
+        save_fig(fig, "01_descriptor_variance")
         return mo.vstack(
             [
                 fig,
@@ -130,7 +134,7 @@ def _(desc_df, mo):
 
 
 @app.cell
-def _(df, mo):
+def _(df, mo, save_fig):
     def _():
         import matplotlib.pyplot as plt
 
@@ -145,6 +149,7 @@ def _(df, mo):
         ax.set_xlabel("Number of molecules")
         ax.set_title("Functional group prevalence across dataset")
         plt.tight_layout()
+        save_fig(fig, "01_functional_groups")
         return mo.vstack(
             [
                 fig,
@@ -159,7 +164,7 @@ def _(df, mo):
 
 
 @app.cell
-def _(desc_df, df):
+def _(desc_df, df, save_fig):
     def _():
         import matplotlib.pyplot as plt
 
@@ -171,6 +176,94 @@ def _(desc_df, df):
         ax.set_ylabel("Count")
         ax.set_title(f"ClogP distribution (n={len(clogp):,} / {len(df):,})")
         plt.tight_layout()
+        save_fig(fig, "01_clogp_distribution")
+        return fig
+
+    _()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+    ## Split Strategy Comparison
+
+    The original TDC scaffold split assigns scaffold groups to splits without
+    balancing the logD distribution.  The stratified scaffold split bins
+    scaffold groups by median logD before assigning them, so each split sees
+    a representative slice of the target range.
+    """
+    )
+    return
+
+
+@app.cell
+def _(df, mo, save_fig):
+    def _():
+        import matplotlib.pyplot as plt
+        from tdc.single_pred import ADME
+
+        from src.data import get_random_split, get_splits
+
+        tdc_split = ADME(name="Lipophilicity_AstraZeneca").get_split(
+            method="scaffold", seed=42
+        )
+        rand_split = get_random_split(seed=42)
+        strat_split = get_splits(seed=42)
+
+        strategies = [
+            ("TDC scaffold", tdc_split),
+            ("Random", rand_split),
+            ("Stratified scaffold", strat_split),
+        ]
+        split_names = ("train", "valid", "test")
+        colors = {"train": "#4e79a7", "valid": "#f28e2b", "test": "#e15759"}
+
+        fig, axes = plt.subplots(3, 3, figsize=(13, 9), sharey=False)
+        bins = 35
+        overall_y = df["Y"].values
+
+        for col, split in enumerate(split_names):
+            for row, (label, splits_dict) in enumerate(strategies):
+                ax = axes[row, col]
+                y = splits_dict[split]["Y"].values
+                ax.hist(
+                    overall_y,
+                    bins=bins,
+                    color="lightgrey",
+                    edgecolor="white",
+                    linewidth=0.3,
+                    label="full dataset",
+                    zorder=1,
+                )
+                ax.hist(
+                    y,
+                    bins=bins,
+                    color=colors[split],
+                    alpha=0.75,
+                    edgecolor="white",
+                    linewidth=0.3,
+                    label=split,
+                    zorder=2,
+                )
+                ax.set_title(
+                    f"{label} — {split}\n"
+                    f"n={len(y)}  mean={y.mean():.2f}  std={y.std():.2f}",
+                    fontsize=9,
+                )
+                ax.set_xlabel("logD")
+                ax.set_ylabel("Count")
+                if col == 0:
+                    ax.legend(fontsize=8)
+
+        plt.suptitle(
+            "logD distribution per split: TDC scaffold (top) · random (middle) · stratified scaffold (bottom)",
+            fontsize=10,
+            y=1.01,
+        )
+        plt.tight_layout()
+        save_fig(fig, "01_split_comparison")
         return fig
 
     _()

--- a/notebooks/03_gnn_model.py
+++ b/notebooks/03_gnn_model.py
@@ -15,6 +15,7 @@ def _():
     from src.explain import AtomAttributionExplainer, plot_atom_contributions
     from src.gnn_model import LipophilicityGNN
     from src.graph_data import ChemBertaEncoder, build_chemprop_dataset
+    from src.plot_utils import save_fig
     from src.train_gnn import evaluate_gnn, load_checkpoint
 
     return (
@@ -28,6 +29,7 @@ def _():
         np,
         pd,
         plot_atom_contributions,
+        save_fig,
         torch,
     )
 
@@ -119,7 +121,7 @@ def _(mo):
 
 
 @app.cell
-def _(ckpt_input, mo, pd):
+def _(ckpt_input, mo, pd, save_fig):
     def _():
         import glob as _glob
         import os as _os
@@ -181,6 +183,7 @@ def _(ckpt_input, mo, pd):
             _ax.legend(fontsize=9)
 
         plt.tight_layout()
+        save_fig(fig, "03_training_curves")
         return mo.vstack(
             [
                 fig,
@@ -259,7 +262,7 @@ def _(mo):
 
 
 @app.cell
-def _(build_chemprop_dataset, device, lm_embs, mo, model, np, splits, torch):
+def _(build_chemprop_dataset, device, lm_embs, mo, model, np, save_fig, splits, torch):
     def _():
         import matplotlib.pyplot as plt
         from chemprop.data import build_dataloader as _dl
@@ -315,6 +318,7 @@ def _(build_chemprop_dataset, device, lm_embs, mo, model, np, splits, torch):
         ax.set_title("GNN + ChemBERTa — Parity Plot")
         ax.legend(fontsize=9)
         plt.tight_layout()
+        save_fig(fig, "03_parity_plot")
         return mo.vstack([fig])
 
     _()
@@ -342,6 +346,7 @@ def _(
     mo,
     model,
     plot_atom_contributions,
+    save_fig,
     splits,
 ):
     def _():
@@ -362,7 +367,7 @@ def _(
         _labels = ["low", "low", "mid", "mid", "high", "high"]
 
         figs = []
-        for _idx, _lbl in zip(_indices, _labels):
+        for _i, (_idx, _lbl) in enumerate(zip(_indices, _labels)):
             _smi = _test.loc[_idx, "Drug"]
             _y = _test.loc[_idx, "Y"]
             _lm = lm_embs["test"][_idx]
@@ -377,6 +382,7 @@ def _(
                     0.5, 0.5, f"Attribution failed:\n{e}", ha="center", va="center"
                 )
                 _ax.axis("off")
+            save_fig(_fig, f"03_attribution_{_i:02d}_{_lbl}")
             figs.append(_fig)
 
         return mo.vstack([mo.hstack(figs[:3]), mo.hstack(figs[3:])])
@@ -479,6 +485,209 @@ def _(
 
     ablation_df = pd.DataFrame(_ablation_rows)
     mo.vstack([mo.md("### Ablation results"), mo.ui.table(ablation_df)])
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+    ## Split Strategy Comparison
+
+    Load the three checkpoints (one per split strategy) to compare parity plots
+    side by side.  Each model is evaluated on the test set it was trained against,
+    so the scaffold splits measure out-of-distribution generalisation while the
+    random split measures interpolation.
+    """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    ckpt_tdc = mo.ui.text(
+        label="TDC scaffold checkpoint",
+        value="checkpoints/glorious-dawn-7-epoch=071-val_mae=0.4416.ckpt",
+    )
+    ckpt_rand = mo.ui.text(
+        label="Random checkpoint",
+        value="checkpoints/lyric-voice-8-epoch=097-val_mae=0.3767.ckpt",
+    )
+    ckpt_strat = mo.ui.text(
+        label="Stratified scaffold checkpoint",
+        value="checkpoints/electric-cherry-9-epoch=093-val_mae=0.4148.ckpt",
+    )
+    mo.vstack([ckpt_tdc, ckpt_rand, ckpt_strat])
+    return ckpt_rand, ckpt_strat, ckpt_tdc
+
+
+@app.cell
+def _(
+    ChemBertaEncoder,
+    build_chemprop_dataset,
+    ckpt_rand,
+    ckpt_strat,
+    ckpt_tdc,
+    device,
+    load_checkpoint,
+    mo,
+    np,
+    save_fig,
+    torch,
+):
+    def _():
+        import matplotlib.pyplot as plt
+        from chemprop.data import build_dataloader as _dl
+        from mpl_toolkits.axes_grid1 import make_axes_locatable
+        from scipy.stats import gaussian_kde
+        from sklearn.metrics import r2_score
+
+        from src.data import get_random_split, get_splits, get_tdc_split
+
+        strategies = [
+            ("TDC scaffold", ckpt_tdc.value.strip(), get_tdc_split),
+            ("Random", ckpt_rand.value.strip(), get_random_split),
+            ("Stratified scaffold", ckpt_strat.value.strip(), get_splits),
+        ]
+        colors = {"train": "#4e79a7", "valid": "#f28e2b", "test": "#e15759"}
+        encoder = ChemBertaEncoder().to(device)
+
+        fig, main_axes = plt.subplots(1, 3, figsize=(18, 5))
+
+        for ax, (label, ckpt_path, split_fn) in zip(main_axes, strategies):
+            divider = make_axes_locatable(ax)
+            ax_top = divider.append_axes("top", size="18%", pad=0.05, sharex=ax)
+            ax_right = divider.append_axes("right", size="18%", pad=0.05, sharey=ax)
+
+            try:
+                _model = load_checkpoint(ckpt_path, device=device)
+            except Exception as e:
+                ax.text(
+                    0.5,
+                    0.5,
+                    f"Load failed:\n{e}",
+                    ha="center",
+                    va="center",
+                    transform=ax.transAxes,
+                )
+                ax.set_title(label)
+                continue
+
+            _splits = split_fn()
+            _split_data = {}
+            _all_vals = []
+
+            for _split in ("train", "valid", "test"):
+                _lm = encoder.encode(_splits[_split]["Drug"].tolist())
+                _loader = _dl(
+                    build_chemprop_dataset(
+                        _splits[_split]["Drug"],
+                        _splits[_split]["Y"].values.astype(np.float32),
+                        _lm,
+                    ),
+                    batch_size=64,
+                    shuffle=False,
+                )
+                _preds, _targets = [], []
+                _model.eval()
+                with torch.no_grad():
+                    for _batch in _loader:
+                        _batch.bmg.to(device)
+                        _preds.append(
+                            _model(
+                                _batch.bmg,
+                                _batch.X_d.to(device)
+                                if _batch.X_d is not None
+                                else None,
+                            )
+                            .squeeze(-1)
+                            .cpu()
+                            .numpy()
+                        )
+                        _targets.append(_batch.Y.squeeze(-1).numpy())
+                _y_pred = np.concatenate(_preds)
+                _y_true = np.concatenate(_targets)
+                _split_data[_split] = (_y_true, _y_pred)
+                _all_vals += list(_y_true) + list(_y_pred)
+
+            _lo, _hi = min(_all_vals) - 0.3, max(_all_vals) + 0.3
+            _x_range = np.linspace(_lo, _hi, 300)
+
+            for _split in ("train", "valid", "test"):
+                _y_true, _y_pred = _split_data[_split]
+                c = colors[_split]
+                _r2 = r2_score(_y_true, _y_pred)
+                _mu_t, _sd_t = float(_y_true.mean()), float(_y_true.std())
+                _mu_p, _sd_p = float(_y_pred.mean()), float(_y_pred.std())
+
+                ax.scatter(
+                    _y_true,
+                    _y_pred,
+                    alpha=0.25,
+                    s=7,
+                    color=c,
+                    label=f"{_split} R²={_r2:.3f}",
+                )
+
+                _kde_x = gaussian_kde(_y_true, bw_method=0.3)
+                ax_top.plot(_x_range, _kde_x(_x_range), color=c, lw=1.5)
+                ax_top.fill_between(_x_range, _kde_x(_x_range), alpha=0.2, color=c)
+                ax_top.axvline(_mu_t, color=c, lw=1, linestyle=":")
+                ax_top.text(
+                    _mu_t,
+                    0.97,
+                    f"μ={_mu_t:.2f}\nσ={_sd_t:.2f}",
+                    transform=ax_top.get_xaxis_transform(),
+                    fontsize=5.5,
+                    color=c,
+                    ha="center",
+                    va="top",
+                    linespacing=1.3,
+                )
+
+                _kde_y = gaussian_kde(_y_pred, bw_method=0.3)
+                ax_right.plot(_kde_y(_x_range), _x_range, color=c, lw=1.5)
+                ax_right.fill_betweenx(_x_range, _kde_y(_x_range), alpha=0.2, color=c)
+                ax_right.axhline(_mu_p, color=c, lw=1, linestyle=":")
+                ax_right.text(
+                    0.97,
+                    _mu_p,
+                    f"μ={_mu_p:.2f}\nσ={_sd_p:.2f}",
+                    transform=ax_right.get_yaxis_transform(),
+                    fontsize=5.5,
+                    color=c,
+                    ha="right",
+                    va="center",
+                    linespacing=1.3,
+                )
+
+            ax.plot([_lo, _hi], [_lo, _hi], "k--", linewidth=1)
+            ax.set_xlim(_lo, _hi)
+            ax.set_ylim(_lo, _hi)
+            ax.set_aspect("equal")
+            ax.set_xlabel("Actual logD")
+            ax.set_ylabel("Predicted logD")
+            ax.legend(fontsize=7, loc="upper left")
+
+            ax_top.set_title(label, fontsize=10)
+            ax_top.set_xlim(_lo, _hi)
+            ax_top.set_yticks([])
+            ax_top.tick_params(labelbottom=False)
+            for _spine in ax_top.spines.values():
+                _spine.set_visible(False)
+
+            ax_right.set_ylim(_lo, _hi)
+            ax_right.set_xticks([])
+            ax_right.tick_params(labelleft=False)
+            for _spine in ax_right.spines.values():
+                _spine.set_visible(False)
+
+        plt.suptitle("Parity plots by split strategy", fontsize=11, y=1.02)
+        plt.tight_layout()
+        save_fig(fig, "03_comparison_parity")
+        return mo.vstack([fig])
+
+    _()
     return
 
 

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -69,6 +69,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="directory for Lightning model checkpoints",
     )
     p.add_argument("--seed", type=int, default=None)
+    p.add_argument(
+        "--split",
+        type=str,
+        default=None,
+        choices=["stratified_scaffold", "random", "tdc_scaffold"],
+        help="train/valid/test split strategy (default: stratified_scaffold)",
+    )
     # Wandb
     p.add_argument(
         "--wandb-project",
@@ -117,6 +124,7 @@ def main() -> None:
         "seed": args.seed,
         "wandb_project": args.wandb_project,
         "wandb_run_name": args.wandb_run_name,
+        "split": args.split,
     }
     cfg.update({k: v for k, v in cli_overrides.items() if v is not None})
 

--- a/src/data.py
+++ b/src/data.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
 import pandas as pd
+from rdkit import Chem
+from rdkit.Chem.Scaffolds.MurckoScaffold import GetScaffoldForMol
 from tdc.single_pred import ADME
 
 
@@ -15,18 +22,179 @@ def load_lipophilicity() -> pd.DataFrame:
     return data.get_data()
 
 
-def get_splits(seed: int = 42) -> dict[str, pd.DataFrame]:
+def _murcko_scaffold(smiles: str) -> str:
     """
-    Return a scaffold split of the dataset as a dict with keys train/valid/test.
+    Return the canonical SMILES of the generic Murcko scaffold for a molecule.
 
-    Scaffold splitting groups structurally similar molecules into the same split,
-    preventing the model from exploiting local structural memorisation across splits.
+    Ring-free molecules (e.g. linear aliphatics) return an empty string and are
+    pooled into a single anonymous scaffold group.
+
+    Params:
+        smiles: str : SMILES string of the molecule
+    Returns:
+        str : canonical scaffold SMILES, or '' for ring-free molecules
+    """
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return ""
+    scaffold_mol = GetScaffoldForMol(mol)
+    return Chem.MolToSmiles(scaffold_mol) if scaffold_mol.GetNumAtoms() > 0 else ""
+
+
+def get_tdc_split(seed: int = 42) -> dict[str, pd.DataFrame]:
+    """
+    Return the original TDC Murcko scaffold split for Lipophilicity-AstraZeneca.
+
+    Scaffold groups are assigned to splits without balancing the logD
+    distribution, so train/valid/test means can differ noticeably.  Use this
+    as the uncontrolled scaffold-split baseline.
+
+    Params:
+        seed: int : random seed passed to TDC's scaffold splitter
+    Returns:
+        dict[str, pd.DataFrame] : keys 'train', 'valid', 'test'; each DataFrame
+            has columns Drug_ID, Drug, Y with index reset
+    """
+    splits = ADME(name="Lipophilicity_AstraZeneca").get_split(
+        method="scaffold", seed=seed
+    )
+    return {name: df.reset_index(drop=True) for name, df in splits.items()}
+
+
+def get_random_split(
+    seed: int = 42,
+    train_frac: float = 0.8,
+    val_frac: float = 0.1,
+) -> dict[str, pd.DataFrame]:
+    """
+    Return a purely random train/valid/test split with no scaffold awareness.
+
+    Molecules are assigned to splits by random shuffling alone, so structurally
+    similar compounds may appear in different splits.  Use this as a baseline
+    to contrast against scaffold-based splits.
 
     Params:
         seed: int : random seed for reproducibility
+        train_frac: float : fraction of molecules to allocate to training
+        val_frac: float : fraction of molecules to allocate to validation
     Returns:
-        dict[str, pd.DataFrame] : each DataFrame has columns Drug_ID, Drug, Y
+        dict[str, pd.DataFrame] : keys 'train', 'valid', 'test'; each DataFrame
+            has columns Drug_ID, Drug, Y with index reset
     """
-    data = ADME(name="Lipophilicity_AstraZeneca")
-    split = data.get_split(method="scaffold", seed=seed)
-    return split
+    from sklearn.model_selection import train_test_split
+
+    test_frac = 1.0 - train_frac - val_frac
+    if test_frac <= 0:
+        raise ValueError(
+            f"train_frac + val_frac must be < 1.0, got {train_frac + val_frac}"
+        )
+
+    df = load_lipophilicity()
+    train_val, test = train_test_split(df, test_size=test_frac, random_state=seed)
+    train, valid = train_test_split(
+        train_val,
+        test_size=val_frac / (train_frac + val_frac),
+        random_state=seed,
+    )
+    return {
+        "train": train.reset_index(drop=True),
+        "valid": valid.reset_index(drop=True),
+        "test": test.reset_index(drop=True),
+    }
+
+
+def get_splits(
+    seed: int = 42,
+    train_frac: float = 0.8,
+    val_frac: float = 0.1,
+    n_strata: int = 5,
+) -> dict[str, pd.DataFrame]:
+    """
+    Return a stratified Murcko scaffold split of the dataset.
+
+    Molecules are grouped by their generic Murcko scaffold so that structurally
+    similar molecules always land in the same split.  Scaffold groups are then
+    binned into n_strata quantile strata by median logD, and a stratified
+    shuffle split is applied at the scaffold-group level so that each split
+    receives a representative slice of the logD distribution.
+
+    The test fraction is inferred as 1 - train_frac - val_frac.  Splitting is
+    performed in two phases using sklearn StratifiedShuffleSplit: first
+    train vs (valid + test), then (valid + test) split equally into valid and
+    test, both at the scaffold-group level.
+
+    Params:
+        seed: int : random seed for reproducibility
+        train_frac: float : fraction of molecules to allocate to training
+        val_frac: float : fraction of molecules to allocate to validation
+        n_strata: int : number of quantile bins for logD stratification
+    Returns:
+        dict[str, pd.DataFrame] : keys 'train', 'valid', 'test'; each DataFrame
+            has columns Drug_ID, Drug, Y with index reset
+    """
+    from sklearn.model_selection import StratifiedShuffleSplit
+
+    test_frac = 1.0 - train_frac - val_frac
+    if test_frac <= 0:
+        raise ValueError(
+            f"train_frac + val_frac must be < 1.0, got {train_frac + val_frac}"
+        )
+
+    df = load_lipophilicity().copy()
+    df["_scaffold"] = df["Drug"].map(_murcko_scaffold)
+
+    # One row per unique scaffold: median logD and molecule count.
+    scaffold_stats = (
+        df.groupby("_scaffold")["Y"].agg(median="median", n="count").reset_index()
+    )
+
+    # Warn if any single scaffold dominates the dataset.
+    large_mask = scaffold_stats["n"] > 0.05 * len(df)
+    for _, row in scaffold_stats[large_mask].iterrows():
+        warnings.warn(
+            f"Scaffold '{row['_scaffold'][:60]}' contains {row['n']} molecules "
+            f"({100 * row['n'] / len(df):.1f}% of dataset) and will be assigned "
+            f"entirely to one split.",
+            stacklevel=2,
+        )
+
+    # Assign strata by rank so each stratum has ~equal scaffold-group count.
+    # Using rank-based bins (not pd.qcut) avoids empty strata when many groups
+    # share the same median logD value.
+    scaffold_stats = scaffold_stats.sort_values("median").reset_index(drop=True)
+    scaffold_stats["_stratum"] = (
+        np.arange(len(scaffold_stats)) * n_strata // len(scaffold_stats)
+    ).astype(int)
+
+    # Phase 1: split scaffold groups into train vs (valid + test).
+    sss1 = StratifiedShuffleSplit(
+        n_splits=1, test_size=(val_frac + test_frac), random_state=seed
+    )
+    train_idx, temp_idx = next(sss1.split(scaffold_stats, scaffold_stats["_stratum"]))
+
+    # Phase 2: split (valid + test) scaffold groups 50/50 → valid and test.
+    temp = scaffold_stats.iloc[temp_idx].reset_index(drop=True)
+    sss2 = StratifiedShuffleSplit(
+        n_splits=1,
+        test_size=test_frac / (val_frac + test_frac),
+        random_state=seed,
+    )
+    val_idx, test_idx = next(sss2.split(temp, temp["_stratum"]))
+    valid_scaffolds = set(temp.iloc[val_idx]["_scaffold"])
+    test_scaffolds = set(temp.iloc[test_idx]["_scaffold"])
+
+    # Map every molecule to its split via its scaffold.
+    def _assign(scaffold: str) -> str:
+        if scaffold in valid_scaffolds:
+            return "valid"
+        if scaffold in test_scaffolds:
+            return "test"
+        return "train"
+
+    df["_split"] = df["_scaffold"].map(_assign)
+    df = df.drop(columns=["_scaffold"])
+
+    return {
+        split: df[df["_split"] == split].drop(columns=["_split"]).reset_index(drop=True)
+        for split in ("train", "valid", "test")
+    }

--- a/src/plot_utils.py
+++ b/src/plot_utils.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+
+def save_fig(
+    fig: plt.Figure,
+    name: str,
+    figs_dir: str | Path = "figs",
+) -> Path:
+    """
+    Save a matplotlib figure as an SVG file in figs_dir.
+
+    Text is kept as editable text elements (svg.fonttype='none') rather than
+    being converted to paths, so labels and titles can be edited directly in
+    Inkscape.  The figs_dir is created if it does not already exist.
+
+    Params:
+        fig: plt.Figure : figure to save
+        name: str : output filename without extension
+        figs_dir: str | Path : directory to write into (default 'figs/')
+    Returns:
+        Path : path to the written .svg file
+    """
+    out_dir = Path(figs_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{name}.svg"
+    with matplotlib.rc_context({"svg.fonttype": "none"}):
+        fig.savefig(out_path, format="svg", bbox_inches="tight")
+    return out_path

--- a/src/train_gnn.py
+++ b/src/train_gnn.py
@@ -13,7 +13,7 @@ from lightning.pytorch.loggers import CSVLogger, WandbLogger
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
-from src.data import get_splits
+from src.data import get_random_split, get_splits, get_tdc_split
 from src.gnn_model import LipophilicityGNN
 from src.graph_data import ChemBertaEncoder, build_chemprop_dataset
 
@@ -71,6 +71,7 @@ class GNNLitModule(L.LightningModule):
         weight_decay: float = 1e-4,
         t_max: int = 100,
         model_kwargs: dict | None = None,
+        split: str = "stratified_scaffold",
     ) -> None:
         """
         Wrap a LipophilicityGNN for Lightning training.
@@ -82,6 +83,7 @@ class GNNLitModule(L.LightningModule):
             t_max: int : CosineAnnealingLR period in epochs
             model_kwargs: dict | None : LipophilicityGNN constructor kwargs, embedded
                 in the checkpoint so load_checkpoint can reconstruct the architecture
+            split: str : split strategy used for training, embedded in the checkpoint
         Returns:
             None
         """
@@ -92,6 +94,7 @@ class GNNLitModule(L.LightningModule):
         self.t_max = t_max
         self.loss_fn = nn.MSELoss()
         self._model_kwargs: dict = model_kwargs or {}
+        self._split = split
 
     def on_save_checkpoint(self, checkpoint: dict) -> None:
         """
@@ -103,6 +106,7 @@ class GNNLitModule(L.LightningModule):
             None
         """
         checkpoint["model_kwargs"] = self._model_kwargs
+        checkpoint["split"] = self._split
 
     def _step(self, batch, split: str) -> torch.Tensor:
         bmg = batch.bmg
@@ -202,6 +206,7 @@ def train_gnn(
         "patience": 20,
         "checkpoint_path": None,
         "seed": 42,
+        "split": "stratified_scaffold",
     }
     if config:
         cfg.update(config)
@@ -212,7 +217,16 @@ def train_gnn(
     ckpt_dir.mkdir(parents=True, exist_ok=True)
 
     # --- Data ---
-    splits = get_splits(seed=cfg["seed"])
+    _split_fns = {
+        "stratified_scaffold": get_splits,
+        "random": get_random_split,
+        "tdc_scaffold": get_tdc_split,
+    }
+    if cfg["split"] not in _split_fns:
+        raise ValueError(
+            f"Unknown split method '{cfg['split']}'. Choose from: {list(_split_fns)}"
+        )
+    splits = _split_fns[cfg["split"]](seed=cfg["seed"])
     encoder = ChemBertaEncoder().to(device)
 
     lm_embs = {
@@ -254,6 +268,7 @@ def train_gnn(
         weight_decay=cfg["weight_decay"],
         t_max=cfg["max_epochs"],
         model_kwargs=model_kwargs,
+        split=cfg["split"],
     )
 
     # --- Loggers ---


### PR DESCRIPTION
## Summary/Issue

Closes #5.

Replaces the TDC scaffold split with a stratified Murcko scaffold split that
balances the logD distribution across train/valid/test while preserving scaffold
integrity. Adds random and TDC scaffold splits as explicit baselines so all three
strategies can be trained against and compared directly in wandb and in a new
notebook section. All notebook plots are now exported as editable SVGs to `figs/`.

## Key Features + Dependencies

- Added `get_tdc_split()`, `get_random_split()`, and `get_splits()` (stratified
  scaffold) to `src/data.py`, each returning the same `dict[str, DataFrame]`
  interface for drop-in interchangeability.
- Added `--split {stratified_scaffold,random,tdc_scaffold}` flag to
  `scripts/train_gnn.py`; default is `stratified_scaffold`. The chosen strategy
  is written into the wandb run config and embedded in the Lightning checkpoint
  alongside `model_kwargs` so runs are self-describing.
- Added `src/plot_utils.py` with `save_fig()`, which writes matplotlib figures as
  editable SVGs to `figs/` with `svg.fonttype=none` so text is selectable in
  Inkscape.
- Updated `notebooks/01_descriptors.py`: all plot cells now call `save_fig()`;
  split comparison extended from 2×3 to 3×3 grid (TDC scaffold / random /
  stratified scaffold).
- Added "Split Strategy Comparison" section to `notebooks/03_gnn_model.py`: three
  checkpoint path inputs (one per strategy) and a 1×3 parity plot with per-split
  KDE marginals on the top and right, mean lines, and μ/σ labels. All GNN notebook
  plots now call `save_fig()`.

## Tests/Test Steps

- [ ] `pixi run python -c "from src.data import get_tdc_split, get_random_split, get_splits; print([len(v) for v in get_splits().values()])"`
  should print `[3436, 383, 381]` with no scaffold leakage warnings.
- [ ] `pixi run train-gnn --split random` and `pixi run train-gnn --split tdc_scaffold`
  complete without error; both runs appear in wandb tagged by their `split` value.
- [ ] `pixi run notebook-eda` renders the 3×3 split comparison; `figs/01_split_comparison.svg`
  is written.
- [ ] `pixi run notebook-gnn` with all three checkpoints filled in renders the
  comparison parity plots with KDE marginals; `figs/03_comparison_parity.svg`
  is written.

## Story

The original TDC scaffold split assigns scaffold groups greedily without regard
for logD distribution, which can produce splits with noticeably different mean
logD. This means val/test metrics partly reflect distribution shift rather than
generalisation difficulty.

The stratified split bins scaffold groups into logD quantile strata and applies
`StratifiedShuffleSplit` at the scaffold-group level, so each split sees a
representative slice of the target range while still holding out entire scaffolds.
Rank-based binning (rather than `pd.qcut`) is used to guarantee equal stratum
sizes when many scaffolds share the same median logD.

Three separate training runs (glorious-dawn-7 / lyric-voice-8 / electric-cherry-9)
confirmed that the random split inflates test R² (0.793) due to scaffold overlap,
while the stratified scaffold split outperforms the TDC scaffold split on test MAE
(0.418 vs 0.429) and R² (0.798 vs 0.762), validating the approach.

## Related Issues / Branches

- Upstream: #2 (GNN + ChemBERTa model, merged)
- The `checkpoints/` directory now contains one checkpoint per split strategy;
  downstream analysis should use the `electric-cherry-9` (stratified scaffold)
  checkpoint as the primary model.

## Other Notes

- `figs/` is excluded by `.gitignore` (`*.svg`); SVGs are regenerated by running
  the notebooks.
- Checkpoints from runs prior to this branch do not contain a `split` key; `load_checkpoint`
  falls back gracefully but the split strategy of those runs is unknown.