### PR TITLE
qm9 pretraining and logd prediction task

### DIFF
--- a/notebooks/04_transformer.py
+++ b/notebooks/04_transformer.py
@@ -1,0 +1,360 @@
+import marimo
+
+__generated_with = "0.23.1"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import numpy as np
+    import pandas as pd
+    import torch
+
+    from src.finetune_transformer import (
+        LogDDataset,
+        evaluate_transformer,
+        load_finetuned_model,
+    )
+    from src.plot_utils import save_fig
+    from src.qm9_data import QM9_TARGETS
+
+    return (
+        LogDDataset,
+        QM9_TARGETS,
+        evaluate_transformer,
+        load_finetuned_model,
+        mo,
+        np,
+        pd,
+        save_fig,
+        torch,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+    # SMILES Transformer — Evaluation Dashboard
+
+    Run pretraining then fine-tuning first:
+    ```
+    pixi run pretrain-transformer
+    pixi run finetune-transformer --pretrained-checkpoint checkpoints/pretrain/<run>.ckpt
+    ```
+    Point the paths below at the fine-tuned checkpoints to explore results.
+    """
+    )
+    return
+
+
+@app.cell
+def _(mo, QM9_TARGETS):
+    from src.qm9_data import QM9_TARGETS as _ALL
+
+    _group_options = {
+        "All 12": _ALL,
+        "Electronic": ["homo", "lumo", "gap", "mu"],
+        "Structural": ["alpha", "r2"],
+        "Thermodynamic": ["u0", "u298", "h298", "g298", "cv", "zpve"],
+        "None (baseline)": [],
+    }
+
+    ablation_inputs = {
+        label: mo.ui.text(
+            label=f"{label} checkpoint",
+            placeholder="checkpoints/finetune/<run>.ckpt",
+        )
+        for label in _group_options
+    }
+    mo.vstack(list(ablation_inputs.values()))
+    return ablation_inputs, _group_options
+
+
+@app.cell
+def _(mo):
+    mo.md("## Per-Split Metrics")
+    return
+
+
+@app.cell
+def _(LogDDataset, ablation_inputs, evaluate_transformer, mo, pd, torch):
+    def _():
+        from torch.utils.data import DataLoader
+
+        from src.data import get_tdc_split
+
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        splits = get_tdc_split()
+
+        rows = []
+        for label, inp in ablation_inputs.items():
+            path = inp.value.strip()
+            if not path or not path.endswith(".ckpt"):
+                continue
+            try:
+                from src.finetune_transformer import load_finetuned_model as _load
+
+                model = _load(path, device=device)
+            except Exception as e:
+                rows.append({"condition": label, "split": "—", "error": str(e)})
+                continue
+            for split_name in ("train", "valid", "test"):
+                loader = DataLoader(
+                    LogDDataset(splits[split_name]),
+                    batch_size=64,
+                    shuffle=False,
+                )
+                m = evaluate_transformer(model, loader, device)
+                rows.append({"condition": label, "split": split_name, **m})
+
+        if not rows:
+            return mo.callout(
+                mo.md("No checkpoints loaded yet. Fill in at least one path above."),
+                kind="warn",
+            )
+        df = pd.DataFrame(rows).round(3)
+        return mo.vstack([mo.md("### Ablation metrics"), mo.ui.table(df)])
+
+    _()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("## Parity Plots by Pretraining Condition")
+    return
+
+
+@app.cell
+def _(LogDDataset, ablation_inputs, mo, np, save_fig, torch):
+    def _():
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.axes_grid1 import make_axes_locatable
+        from scipy.stats import gaussian_kde
+        from sklearn.metrics import r2_score
+        from torch.utils.data import DataLoader
+
+        from src.data import get_tdc_split
+        from src.finetune_transformer import load_finetuned_model as _load
+
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        splits = get_tdc_split()
+        colors = {"train": "#4e79a7", "valid": "#f28e2b", "test": "#e15759"}
+
+        entries = [
+            (label, inp.value.strip())
+            for label, inp in ablation_inputs.items()
+            if inp.value.strip().endswith(".ckpt")
+        ]
+        if not entries:
+            return mo.callout(mo.md("No checkpoints loaded."), kind="warn")
+
+        fig, main_axes = plt.subplots(1, len(entries), figsize=(6 * len(entries), 5))
+        if len(entries) == 1:
+            main_axes = [main_axes]
+
+        for ax, (label, ckpt_path) in zip(main_axes, entries):
+            divider = make_axes_locatable(ax)
+            ax_top = divider.append_axes("top", size="18%", pad=0.05, sharex=ax)
+            ax_right = divider.append_axes("right", size="18%", pad=0.05, sharey=ax)
+
+            try:
+                model = _load(ckpt_path, device=device)
+            except Exception as e:
+                ax.text(
+                    0.5,
+                    0.5,
+                    f"Load failed:\n{e}",
+                    ha="center",
+                    va="center",
+                    transform=ax.transAxes,
+                )
+                ax_top.set_title(label, fontsize=9)
+                continue
+
+            _split_data = {}
+            _all_vals = []
+            for _split in ("train", "valid", "test"):
+                loader = DataLoader(
+                    LogDDataset(splits[_split]),
+                    batch_size=64,
+                    shuffle=False,
+                )
+                _preds, _targets = [], []
+                model.eval()
+                with torch.no_grad():
+                    for batch in loader:
+                        out = (
+                            model(
+                                batch["input_ids"].to(device),
+                                batch["attention_mask"].to(device),
+                            )
+                            .squeeze(-1)
+                            .cpu()
+                            .numpy()
+                        )
+                        _preds.append(out)
+                        _targets.append(batch["label"].numpy())
+                _y_pred = np.concatenate(_preds)
+                _y_true = np.concatenate(_targets)
+                _split_data[_split] = (_y_true, _y_pred)
+                _all_vals += list(_y_true) + list(_y_pred)
+
+            _lo, _hi = min(_all_vals) - 0.3, max(_all_vals) + 0.3
+            _x_range = np.linspace(_lo, _hi, 300)
+
+            for _split in ("train", "valid", "test"):
+                _y_true, _y_pred = _split_data[_split]
+                c = colors[_split]
+                _r2 = r2_score(_y_true, _y_pred)
+                _mu_t, _sd_t = float(_y_true.mean()), float(_y_true.std())
+                _mu_p, _sd_p = float(_y_pred.mean()), float(_y_pred.std())
+
+                ax.scatter(
+                    _y_true,
+                    _y_pred,
+                    alpha=0.25,
+                    s=7,
+                    color=c,
+                    label=f"{_split} R²={_r2:.3f}",
+                )
+
+                _kde_x = gaussian_kde(_y_true, bw_method=0.3)
+                ax_top.plot(_x_range, _kde_x(_x_range), color=c, lw=1.5)
+                ax_top.fill_between(_x_range, _kde_x(_x_range), alpha=0.2, color=c)
+                ax_top.axvline(_mu_t, color=c, lw=1, linestyle=":")
+                ax_top.text(
+                    _mu_t,
+                    0.97,
+                    f"μ={_mu_t:.2f}\nσ={_sd_t:.2f}",
+                    transform=ax_top.get_xaxis_transform(),
+                    fontsize=5.5,
+                    color=c,
+                    ha="center",
+                    va="top",
+                    linespacing=1.3,
+                )
+
+                _kde_y = gaussian_kde(_y_pred, bw_method=0.3)
+                ax_right.plot(_kde_y(_x_range), _x_range, color=c, lw=1.5)
+                ax_right.fill_betweenx(_x_range, _kde_y(_x_range), alpha=0.2, color=c)
+                ax_right.axhline(_mu_p, color=c, lw=1, linestyle=":")
+                ax_right.text(
+                    0.97,
+                    _mu_p,
+                    f"μ={_mu_p:.2f}\nσ={_sd_p:.2f}",
+                    transform=ax_right.get_yaxis_transform(),
+                    fontsize=5.5,
+                    color=c,
+                    ha="right",
+                    va="center",
+                    linespacing=1.3,
+                )
+
+            ax.plot([_lo, _hi], [_lo, _hi], "k--", linewidth=1)
+            ax.set_xlim(_lo, _hi)
+            ax.set_ylim(_lo, _hi)
+            ax.set_aspect("equal")
+            ax.set_xlabel("Actual logD")
+            ax.set_ylabel("Predicted logD")
+            ax.legend(fontsize=7, loc="upper left")
+
+            ax_top.set_title(label, fontsize=9)
+            ax_top.set_xlim(_lo, _hi)
+            ax_top.set_yticks([])
+            ax_top.tick_params(labelbottom=False)
+            for _spine in ax_top.spines.values():
+                _spine.set_visible(False)
+
+            ax_right.set_ylim(_lo, _hi)
+            ax_right.set_xticks([])
+            ax_right.tick_params(labelleft=False)
+            for _spine in ax_right.spines.values():
+                _spine.set_visible(False)
+
+        plt.suptitle("Parity plots by pretraining condition", fontsize=11, y=1.02)
+        plt.tight_layout()
+        save_fig(fig, "04_transformer_parity")
+        return mo.vstack([fig])
+
+    _()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("## Training Curves")
+    return
+
+
+@app.cell
+def _(mo, pd):
+    def _():
+        import glob as _glob
+        import os as _os
+
+        import matplotlib.pyplot as plt
+
+        _dirs = {
+            "Pretrain": "checkpoints/pretrain",
+            "Finetune": "checkpoints/finetune",
+        }
+        _colors = {"train": "#4e79a7", "val": "#e15759"}
+        _window = 5
+
+        for _phase, _ckpt_dir in _dirs.items():
+            _csv = _os.path.join(_ckpt_dir, f"{_phase.lower()}_metrics_history.csv")
+            if not _os.path.exists(_csv):
+                _candidates = sorted(
+                    _glob.glob(
+                        _os.path.join(_ckpt_dir, "logs", "**", "metrics.csv"),
+                        recursive=True,
+                    )
+                )
+                if _candidates:
+                    _csv = _candidates[-1]
+            if not _os.path.exists(_csv):
+                continue
+
+            _df = pd.read_csv(_csv)
+            _metric = "loss"
+            fig, ax = plt.subplots(figsize=(8, 3))
+            for _split in ("train", "val"):
+                _col = f"{_split}_{_metric}"
+                if _col not in _df.columns:
+                    continue
+                _sub = _df[["epoch", _col]].dropna(subset=[_col])
+                _by_epoch = _sub.groupby("epoch")[_col].mean()
+                ax.plot(
+                    _by_epoch.index,
+                    _by_epoch.values,
+                    alpha=0.3,
+                    color=_colors[_split],
+                    linewidth=0.8,
+                )
+                ax.plot(
+                    _by_epoch.index,
+                    _by_epoch.rolling(_window, min_periods=1).mean(),
+                    color=_colors[_split],
+                    linewidth=2,
+                    label=f"{_split} ({_window}-ep mean)",
+                )
+            ax.set_xlabel("Epoch")
+            ax.set_ylabel("MSE Loss")
+            ax.set_title(f"{_phase} loss vs epoch")
+            ax.legend(fontsize=9)
+            plt.tight_layout()
+
+            from src.plot_utils import save_fig as _sf
+
+            _sf(fig, f"04_transformer_{_phase.lower()}_curves")
+            mo.vstack([fig])
+
+    _()
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pixi.toml
+++ b/pixi.toml
@@ -64,10 +64,17 @@ setup-tdc = "python -m pip install PyTDC --no-deps"
 # --- training ---
 train-gnn = "python scripts/train_gnn.py"
 
+# --- transformer pretraining / fine-tuning ---
+# Phase 1: pretrain on QM9 (pass --targets to run ablations)
+pretrain-transformer = "python scripts/pretrain_qm9.py"
+# Phase 2: fine-tune on logD (pass --pretrained-checkpoint for pretrained init)
+finetune-transformer  = "python scripts/finetune_logd.py"
+
 # --- notebooks ---
 # --no-token skips the login wall; safe for local/remote-SSH use
-notebook-gnn = "marimo edit --no-token notebooks/03_gnn_model.py"
-notebook-eda = "marimo edit --no-token notebooks/01_descriptors.py"
+notebook-gnn         = "marimo edit --no-token notebooks/03_gnn_model.py"
+notebook-eda         = "marimo edit --no-token notebooks/01_descriptors.py"
+notebook-transformer = "marimo edit --no-token notebooks/04_transformer.py"
 
 # --- tests ---
 test = "pytest tests/ -v"

--- a/scripts/finetune_logd.py
+++ b/scripts/finetune_logd.py
@@ -1,0 +1,112 @@
+"""
+Fine-tune the pretrained SMILES transformer on logD (phase 2).
+
+Usage
+-----
+    # with pretrained backbone
+    pixi run finetune-transformer --pretrained-checkpoint checkpoints/pretrain/<run>.ckpt
+
+    # no-pretraining baseline (unfrozen ChemBERTa fine-tuned directly)
+    pixi run finetune-transformer
+
+    # custom hyperparameters
+    pixi run finetune-transformer --pretrained-checkpoint <path> --lr 5e-6 --max-epochs 30
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """
+    Build the argument parser for logD fine-tuning.
+
+    Params:
+        None
+    Returns:
+        argparse.ArgumentParser : configured parser
+    """
+    p = argparse.ArgumentParser(
+        description="Fine-tune SMILES transformer on logD",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--pretrained-checkpoint",
+        type=str,
+        default=None,
+        help="Phase-1 .ckpt path; omit to fine-tune without pretraining (baseline)",
+    )
+    p.add_argument(
+        "--d-hidden", type=int, default=None, help="LogDFinetuneHead hidden dim"
+    )
+    p.add_argument("--dropout", type=float, default=None)
+    p.add_argument("--lr", type=float, default=None)
+    p.add_argument("--weight-decay", type=float, default=None)
+    p.add_argument("--warmup-steps", type=int, default=None)
+    p.add_argument("--batch-size", type=int, default=None)
+    p.add_argument("--max-epochs", type=int, default=None)
+    p.add_argument("--patience", type=int, default=None)
+    p.add_argument("--max-length", type=int, default=None)
+    p.add_argument("--seed", type=int, default=None)
+    p.add_argument(
+        "--checkpoint-dir",
+        type=Path,
+        default=Path("checkpoints/finetune"),
+    )
+    p.add_argument("--wandb-project", type=str, default=None)
+    p.add_argument("--wandb-run-name", type=str, default=None)
+    return p
+
+
+def main() -> None:
+    """
+    Parse arguments, run fine-tuning, and print metrics summary.
+
+    Params:
+        None
+    Returns:
+        None
+    """
+    args = _build_parser().parse_args()
+
+    cli_overrides = {
+        "pretrained_checkpoint": args.pretrained_checkpoint,
+        "d_hidden": args.d_hidden,
+        "dropout": args.dropout,
+        "lr": args.lr,
+        "weight_decay": args.weight_decay,
+        "warmup_steps": args.warmup_steps,
+        "batch_size": args.batch_size,
+        "max_epochs": args.max_epochs,
+        "patience": args.patience,
+        "max_length": args.max_length,
+        "seed": args.seed,
+        "wandb_project": args.wandb_project,
+        "wandb_run_name": args.wandb_run_name,
+    }
+    cfg = {k: v for k, v in cli_overrides.items() if v is not None}
+
+    from src.finetune_transformer import (  # deferred: avoids heavy imports on --help
+        finetune,
+    )
+
+    _, metrics = finetune(config=cfg, checkpoint_dir=args.checkpoint_dir)
+
+    print("\n" + "=" * 46)
+    print(f"{'split':<8}  {'RMSE':>7}  {'MAE':>7}  {'R²':>7}")
+    print("-" * 46)
+    for split, m in metrics.items():
+        print(f"{split:<8}  {m['rmse']:>7.4f}  {m['mae']:>7.4f}  {m['r2']:>7.4f}")
+    print("=" * 46)
+
+    out_path = Path(args.checkpoint_dir) / "finetune_metrics.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(metrics, f, indent=2)
+    print(f"\nMetrics saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pretrain_qm9.py
+++ b/scripts/pretrain_qm9.py
@@ -1,0 +1,109 @@
+"""
+Pretrain the SMILES transformer on QM9 multi-task regression (phase 1).
+
+Usage
+-----
+    # all 12 QM9 targets (default)
+    pixi run pretrain-transformer
+
+    # ablation: electronic properties only
+    pixi run pretrain-transformer --targets homo lumo gap mu
+
+    # custom hyperparameters
+    pixi run pretrain-transformer --lr 1e-5 --max-epochs 20 --batch-size 64
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from src.qm9_data import QM9_TARGETS
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """
+    Build the argument parser for QM9 pretraining.
+
+    Params:
+        None
+    Returns:
+        argparse.ArgumentParser : configured parser
+    """
+    p = argparse.ArgumentParser(
+        description="Pretrain SMILES transformer on QM9",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--targets",
+        nargs="+",
+        default=None,
+        choices=QM9_TARGETS,
+        metavar="TARGET",
+        help=(
+            f"QM9 targets to pretrain on (default: all {len(QM9_TARGETS)}). "
+            f"Choices: {QM9_TARGETS}"
+        ),
+    )
+    p.add_argument("--lr", type=float, default=None)
+    p.add_argument("--weight-decay", type=float, default=None)
+    p.add_argument("--warmup-steps", type=int, default=None)
+    p.add_argument("--batch-size", type=int, default=None)
+    p.add_argument("--max-epochs", type=int, default=None)
+    p.add_argument("--patience", type=int, default=None)
+    p.add_argument(
+        "--max-length", type=int, default=None, help="Tokenizer max sequence length"
+    )
+    p.add_argument("--seed", type=int, default=None)
+    p.add_argument(
+        "--qm9-split",
+        choices=["stratified_scaffold", "random"],
+        default=None,
+        help="QM9 split strategy for pretraining (default: stratified_scaffold)",
+    )
+    p.add_argument(
+        "--checkpoint-dir",
+        type=Path,
+        default=Path("checkpoints/pretrain"),
+    )
+    p.add_argument("--wandb-project", type=str, default=None)
+    p.add_argument("--wandb-run-name", type=str, default=None)
+    return p
+
+
+def main() -> None:
+    """
+    Parse arguments and run QM9 pretraining.
+
+    Params:
+        None
+    Returns:
+        None
+    """
+    args = _build_parser().parse_args()
+
+    cli_overrides = {
+        "targets": args.targets,
+        "lr": args.lr,
+        "weight_decay": args.weight_decay,
+        "warmup_steps": args.warmup_steps,
+        "batch_size": args.batch_size,
+        "max_epochs": args.max_epochs,
+        "patience": args.patience,
+        "max_length": args.max_length,
+        "seed": args.seed,
+        "qm9_split": args.qm9_split,
+        "wandb_project": args.wandb_project,
+        "wandb_run_name": args.wandb_run_name,
+    }
+    cfg = {k: v for k, v in cli_overrides.items() if v is not None}
+
+    from src.pretrain_transformer import (  # deferred: avoids heavy imports on --help
+        pretrain,
+    )
+
+    best_ckpt = pretrain(config=cfg, checkpoint_dir=args.checkpoint_dir)
+    print(f"\nBest pretrain checkpoint: {best_ckpt}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/finetune_transformer.py
+++ b/src/finetune_transformer.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import lightning as L
+import numpy as np
+import torch
+import torch.nn as nn
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
+from lightning.pytorch.loggers import CSVLogger, WandbLogger
+from lightning.pytorch.utilities.types import OptimizerLRScheduler
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from torch.utils.data import DataLoader, Dataset
+
+from src.data import get_tdc_split
+from src.pretrain_transformer import load_pretrained_backbone
+from src.transformer_model import (
+    CHEMBERTA_MODEL,
+    LogDFinetuneHead,
+    SMILESTransformer,
+    tokenize,
+)
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+
+class LogDDataset(Dataset):
+    """
+    PyTorch Dataset wrapping a logD DataFrame split.
+
+    Tokenization is performed once at construction to avoid re-tokenizing on
+    every batch.
+    """
+
+    def __init__(self, df, max_length: int = 128) -> None:
+        """
+        Tokenize SMILES and store logD targets.
+
+        Params:
+            df: pd.DataFrame : split DataFrame with 'Drug' and 'Y' columns
+            max_length: int : tokenizer max sequence length
+        Returns:
+            None
+        """
+        enc = tokenize(df["Drug"].tolist(), max_length=max_length)
+        self.input_ids = enc["input_ids"]
+        self.attention_mask = enc["attention_mask"]
+        self.labels = torch.tensor(df["Y"].values, dtype=torch.float32)
+
+    def __len__(self) -> int:
+        """
+        Return dataset size.
+
+        Params:
+            None
+        Returns:
+            int : number of molecules
+        """
+        return len(self.input_ids)
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        """
+        Return tokenized inputs and logD target for one molecule.
+
+        Params:
+            idx: int : sample index
+        Returns:
+            dict[str, torch.Tensor] : 'input_ids', 'attention_mask', 'label'
+        """
+        return {
+            "input_ids": self.input_ids[idx],
+            "attention_mask": self.attention_mask[idx],
+            "label": self.labels[idx],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Lightning module
+# ---------------------------------------------------------------------------
+
+
+class FinetuneLitModule(L.LightningModule):
+    """Lightning wrapper for logD fine-tuning of SMILESTransformer."""
+
+    def __init__(
+        self,
+        model: SMILESTransformer,
+        lr: float = 1e-5,
+        weight_decay: float = 1e-2,
+        warmup_steps: int = 100,
+        t_max: int = 50,
+        head_kwargs: dict | None = None,
+        pretrained_checkpoint: str | None = None,
+        pretrain_targets: list[str] | None = None,
+    ) -> None:
+        """
+        Wrap SMILESTransformer for logD regression.
+
+        Params:
+            model: SMILESTransformer : model with LogDFinetuneHead attached
+            lr: float : peak AdamW learning rate
+            weight_decay: float : AdamW weight decay
+            warmup_steps: int : linear warmup steps before cosine decay
+            t_max: int : CosineAnnealingLR period in epochs
+            head_kwargs: dict | None : LogDFinetuneHead constructor kwargs,
+                embedded in checkpoint for self-contained loading
+            pretrained_checkpoint: str | None : path to phase-1 checkpoint,
+                embedded for traceability
+            pretrain_targets: list[str] | None : QM9 targets used in phase 1,
+                embedded for ablation tracking
+        Returns:
+            None
+        """
+        super().__init__()
+        self.model = model
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.warmup_steps = warmup_steps
+        self.t_max = t_max
+        self.loss_fn = nn.MSELoss()
+        self._head_kwargs = head_kwargs or {}
+        self._pretrained_checkpoint = pretrained_checkpoint
+        self._pretrain_targets = pretrain_targets or []
+
+    def on_save_checkpoint(self, checkpoint: dict) -> None:
+        """
+        Embed head kwargs and provenance in the checkpoint.
+
+        Params:
+            checkpoint: dict : Lightning checkpoint dict (mutated in place)
+        Returns:
+            None
+        """
+        checkpoint["head_kwargs"] = self._head_kwargs
+        checkpoint["pretrained_checkpoint"] = self._pretrained_checkpoint
+        checkpoint["pretrain_targets"] = self._pretrain_targets
+
+    def _step(self, batch: dict, split: str) -> torch.Tensor:
+        preds = self.model(batch["input_ids"], batch["attention_mask"]).squeeze(-1)
+        targets = batch["label"]
+        loss = self.loss_fn(preds, targets)
+        mae = (preds - targets).abs().mean()
+        self.log(
+            f"{split}_loss", loss, prog_bar=(split == "val"), batch_size=len(targets)
+        )
+        self.log(
+            f"{split}_mae", mae, prog_bar=(split == "val"), batch_size=len(targets)
+        )
+        return loss
+
+    def training_step(self, batch: Any, _batch_idx: int) -> torch.Tensor:
+        """
+        Compute MSE loss for a training batch.
+
+        Params:
+            batch: Any : dict with input_ids, attention_mask, label
+            _batch_idx: int : batch index (unused)
+        Returns:
+            torch.Tensor : scalar MSE loss
+        """
+        return self._step(batch, "train")
+
+    def validation_step(self, batch: Any, _batch_idx: int) -> None:
+        """
+        Log validation MAE and loss.
+
+        Params:
+            batch: Any : dict with input_ids, attention_mask, label
+            _batch_idx: int : batch index (unused)
+        Returns:
+            None
+        """
+        self._step(batch, "val")
+
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        """
+        Return AdamW with linear warmup and cosine annealing.
+
+        A lower learning rate than pretraining is used to avoid destroying the
+        pretrained representations during fine-tuning.
+
+        Params:
+            None
+        Returns:
+            dict : Lightning optimizer/scheduler config
+        """
+        opt = torch.optim.AdamW(
+            self.model.parameters(), lr=self.lr, weight_decay=self.weight_decay
+        )
+        warmup = torch.optim.lr_scheduler.LinearLR(
+            opt, start_factor=1e-3, end_factor=1.0, total_iters=self.warmup_steps
+        )
+        cosine = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=self.t_max)
+        scheduler = torch.optim.lr_scheduler.SequentialLR(
+            opt, schedulers=[warmup, cosine], milestones=[self.warmup_steps]
+        )
+        return {
+            "optimizer": opt,
+            "lr_scheduler": {"scheduler": scheduler, "interval": "step"},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Evaluation helper
+# ---------------------------------------------------------------------------
+
+
+def evaluate_transformer(
+    model: SMILESTransformer,
+    loader: DataLoader,
+    device: torch.device,
+) -> dict[str, float]:
+    """
+    Compute RMSE, MAE, and R² for a fine-tuned SMILESTransformer.
+
+    Params:
+        model: SMILESTransformer : fine-tuned model in eval mode
+        loader: DataLoader : LogDDataset DataLoader
+        device: torch.device : inference device
+    Returns:
+        dict[str, float] : keys 'rmse', 'mae', 'r2'
+    """
+    model.eval()
+    preds, targets = [], []
+    with torch.no_grad():
+        for batch in loader:
+            out = (
+                model(
+                    batch["input_ids"].to(device),
+                    batch["attention_mask"].to(device),
+                )
+                .squeeze(-1)
+                .cpu()
+                .numpy()
+            )
+            preds.append(out)
+            targets.append(batch["label"].numpy())
+    y_pred = np.concatenate(preds)
+    y_true = np.concatenate(targets)
+    return {
+        "rmse": float(mean_squared_error(y_true, y_pred) ** 0.5),
+        "mae": float(mean_absolute_error(y_true, y_pred)),
+        "r2": float(r2_score(y_true, y_pred)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Training entry point
+# ---------------------------------------------------------------------------
+
+
+def finetune(
+    config: dict | None = None,
+    checkpoint_dir: str | Path = "checkpoints/finetune",
+) -> tuple[SMILESTransformer, dict[str, dict[str, float]]]:
+    """
+    Fine-tune a pretrained SMILESTransformer on the logD AstraZeneca dataset.
+
+    Loads a phase-1 checkpoint (if provided), swaps in a LogDFinetuneHead, and
+    fine-tunes end-to-end on the TDC scaffold split.
+
+    Params:
+        config: dict | None : hyperparameters; missing keys fall back to defaults
+        checkpoint_dir: str | Path : directory for Lightning checkpoints
+    Returns:
+        tuple[SMILESTransformer, dict] : best fine-tuned model and metrics per split
+    """
+    cfg = {
+        "pretrained_checkpoint": None,  # path to phase-1 .ckpt; None = no pretraining
+        "d_hidden": 256,
+        "dropout": 0.1,
+        "lr": 1e-5,
+        "weight_decay": 1e-2,
+        "warmup_steps": 100,
+        "batch_size": 32,
+        "max_epochs": 50,
+        "patience": 10,
+        "max_length": 128,
+        "seed": 42,
+        "split": "tdc_scaffold",
+        "wandb_project": "lipophilicity_pred",
+        "wandb_run_name": None,
+    }
+    if config:
+        cfg.update(config)
+
+    L.seed_everything(cfg["seed"], workers=True)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    ckpt_dir = Path(checkpoint_dir)
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Data ---
+    splits = get_tdc_split(seed=cfg["seed"])
+    train_ds = LogDDataset(splits["train"], max_length=cfg["max_length"])
+    val_ds = LogDDataset(splits["valid"], max_length=cfg["max_length"])
+    test_ds = LogDDataset(splits["test"], max_length=cfg["max_length"])
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=cfg["batch_size"],
+        shuffle=True,
+        num_workers=4,
+        pin_memory=True,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=cfg["batch_size"],
+        shuffle=False,
+        num_workers=4,
+        pin_memory=True,
+    )
+    test_loader = DataLoader(
+        test_ds,
+        batch_size=cfg["batch_size"],
+        shuffle=False,
+        num_workers=4,
+        pin_memory=True,
+    )
+
+    # --- Model ---
+    head_kwargs = {
+        "d_model": 768,
+        "d_hidden": cfg["d_hidden"],
+        "dropout": cfg["dropout"],
+    }
+    head = LogDFinetuneHead(**head_kwargs)
+    pretrain_targets: list[str] = []
+
+    pretrained_ckpt = cfg.get("pretrained_checkpoint")
+    if pretrained_ckpt:
+        model, pretrain_targets, _ = load_pretrained_backbone(pretrained_ckpt, device)
+        model.swap_head(head)
+    else:
+        model = SMILESTransformer(head=head, model_name=CHEMBERTA_MODEL)
+    model = model.to(device)
+
+    # --- Loggers ---
+    wandb_logger = WandbLogger(
+        project=cfg["wandb_project"],
+        name=cfg.get("wandb_run_name"),
+        config={
+            **cfg,
+            "phase": "finetune",
+            "pretrain_targets": pretrain_targets,
+        },
+    )
+    csv_logger = CSVLogger(save_dir=str(ckpt_dir), name="logs")
+    run_name = wandb_logger.experiment.name
+
+    # --- Callbacks ---
+    early_stop = EarlyStopping(monitor="val_mae", patience=cfg["patience"], mode="min")
+    ckpt_cb = ModelCheckpoint(
+        dirpath=ckpt_dir,
+        filename=f"{run_name}-finetune-{{epoch:03d}}-{{val_mae:.4f}}",
+        monitor="val_mae",
+        mode="min",
+        save_top_k=1,
+    )
+
+    lit = FinetuneLitModule(
+        model,
+        lr=cfg["lr"],
+        weight_decay=cfg["weight_decay"],
+        warmup_steps=cfg["warmup_steps"],
+        t_max=cfg["max_epochs"],
+        head_kwargs=head_kwargs,
+        pretrained_checkpoint=pretrained_ckpt,
+        pretrain_targets=pretrain_targets,
+    )
+
+    trainer = L.Trainer(
+        max_epochs=cfg["max_epochs"],
+        accelerator="auto",
+        callbacks=[early_stop, ckpt_cb],
+        gradient_clip_val=1.0,
+        log_every_n_steps=1,
+        enable_progress_bar=True,
+        logger=[wandb_logger, csv_logger],
+    )
+    trainer.fit(lit, train_loader, val_loader)
+
+    import shutil
+
+    history_src = Path(csv_logger.log_dir) / "metrics.csv"
+    history_dst = ckpt_dir / "finetune_metrics_history.csv"
+    if history_src.exists():
+        shutil.copy(history_src, history_dst)
+
+    # Load best weights back
+    best_ckpt = torch.load(
+        ckpt_cb.best_model_path, map_location=device, weights_only=False
+    )
+    model_state = {
+        k[len("model.") :]: v
+        for k, v in best_ckpt["state_dict"].items()
+        if k.startswith("model.")
+    }
+    model.load_state_dict(model_state)
+    best_model = model.to(device).eval()
+
+    loaders = {"train": train_loader, "valid": val_loader, "test": test_loader}
+    metrics = {
+        split: evaluate_transformer(best_model, loader, device)
+        for split, loader in loaders.items()
+    }
+    return best_model, metrics
+
+
+def load_finetuned_model(
+    checkpoint_path: str | Path,
+    device: torch.device | None = None,
+) -> SMILESTransformer:
+    """
+    Restore a fine-tuned SMILESTransformer from a Lightning checkpoint.
+
+    Params:
+        checkpoint_path: str | Path : path to the .ckpt file from finetune()
+        device: torch.device | None : target device; defaults to CUDA if available
+    Returns:
+        SMILESTransformer : model in eval mode on the requested device
+    """
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    ckpt = torch.load(checkpoint_path, map_location=device, weights_only=False)
+    head_kwargs = ckpt.get(
+        "head_kwargs", {"d_model": 768, "d_hidden": 256, "dropout": 0.1}
+    )
+    head = LogDFinetuneHead(**head_kwargs)
+    model = SMILESTransformer(head=head, model_name=CHEMBERTA_MODEL)
+
+    state = {
+        k[len("model.") :]: v
+        for k, v in ckpt["state_dict"].items()
+        if k.startswith("model.")
+    }
+    model.load_state_dict(state)
+    return model.to(device).eval()

--- a/src/pretrain_transformer.py
+++ b/src/pretrain_transformer.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import lightning as L
+import numpy as np
+import torch
+import torch.nn as nn
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
+from lightning.pytorch.loggers import CSVLogger, WandbLogger
+from lightning.pytorch.utilities.types import OptimizerLRScheduler
+from torch.utils.data import DataLoader, Dataset
+
+from src.qm9_data import QM9_TARGETS, QM9Normalizer, get_qm9_splits
+from src.transformer_model import (
+    CHEMBERTA_MODEL,
+    QM9PretrainHead,
+    SMILESTransformer,
+    tokenize,
+)
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+
+class QM9Dataset(Dataset):
+    """
+    PyTorch Dataset wrapping a QM9 DataFrame split.
+
+    Tokenization is performed once at construction time (the tokenizer is
+    CPU-only and cheap to cache) to avoid repeated tokenization during
+    training.  Normalised targets are stored as a float32 tensor.
+    """
+
+    def __init__(
+        self,
+        df,
+        targets: list[str],
+        normalizer: QM9Normalizer,
+        max_length: int = 128,
+    ) -> None:
+        """
+        Tokenize SMILES and normalise targets up front.
+
+        Params:
+            df: pd.DataFrame : split DataFrame with 'Drug' and target columns
+            targets: list[str] : QM9 target column names to include
+            normalizer: QM9Normalizer : fitted normaliser
+            max_length: int : tokenizer max sequence length
+        Returns:
+            None
+        """
+        enc = tokenize(df["Drug"].tolist(), max_length=max_length)
+        self.input_ids = enc["input_ids"]
+        self.attention_mask = enc["attention_mask"]
+        self.labels = torch.tensor(
+            normalizer.transform(df, targets), dtype=torch.float32
+        )
+
+    def __len__(self) -> int:
+        """
+        Return dataset size.
+
+        Params:
+            None
+        Returns:
+            int : number of molecules
+        """
+        return len(self.input_ids)
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        """
+        Return tokenized inputs and normalised targets for one molecule.
+
+        Params:
+            idx: int : sample index
+        Returns:
+            dict[str, torch.Tensor] : 'input_ids', 'attention_mask', 'labels'
+        """
+        return {
+            "input_ids": self.input_ids[idx],
+            "attention_mask": self.attention_mask[idx],
+            "labels": self.labels[idx],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Lightning module
+# ---------------------------------------------------------------------------
+
+
+class PretrainLitModule(L.LightningModule):
+    """Lightning wrapper for multi-task QM9 pretraining of SMILESTransformer."""
+
+    def __init__(
+        self,
+        model: SMILESTransformer,
+        targets: list[str],
+        normalizer: QM9Normalizer,
+        lr: float = 2e-5,
+        weight_decay: float = 1e-2,
+        warmup_steps: int = 500,
+        t_max: int = 10,
+        qm9_split: str = "stratified_scaffold",
+    ) -> None:
+        """
+        Wrap SMILESTransformer for QM9 multi-task regression.
+
+        Params:
+            model: SMILESTransformer : model with QM9PretrainHead attached
+            targets: list[str] : QM9 target names being predicted
+            normalizer: QM9Normalizer : fitted normaliser, embedded in checkpoint
+            lr: float : peak AdamW learning rate
+            weight_decay: float : AdamW weight decay
+            warmup_steps: int : linear warmup steps before cosine decay
+            t_max: int : CosineAnnealingLR period in epochs
+            qm9_split: str : split strategy used for pretraining, embedded in checkpoint
+        Returns:
+            None
+        """
+        super().__init__()
+        self.model = model
+        self.targets = targets
+        self.normalizer = normalizer
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.warmup_steps = warmup_steps
+        self.t_max = t_max
+        self.qm9_split = qm9_split
+        self.loss_fn = nn.MSELoss()
+
+    def on_save_checkpoint(self, checkpoint: dict) -> None:
+        """
+        Embed targets and normaliser state in the checkpoint.
+
+        Params:
+            checkpoint: dict : Lightning checkpoint dict (mutated in place)
+        Returns:
+            None
+        """
+        checkpoint["pretrain_targets"] = self.targets
+        checkpoint["normalizer_state"] = self.normalizer.state_dict()
+        checkpoint["qm9_split"] = self.qm9_split
+
+    def _step(self, batch: dict, split: str) -> torch.Tensor:
+        preds = self.model(batch["input_ids"], batch["attention_mask"])
+        loss = self.loss_fn(preds, batch["labels"])
+        # Per-target MAE for interpretability in wandb
+        per_target_mae = (preds - batch["labels"]).abs().mean(dim=0)
+        self.log(
+            f"{split}_loss",
+            loss,
+            prog_bar=(split == "val"),
+            batch_size=len(batch["labels"]),
+        )
+        for name, mae in zip(self.targets, per_target_mae):
+            self.log(f"{split}_mae_{name}", mae, batch_size=len(batch["labels"]))
+        return loss
+
+    def training_step(self, batch: Any, _batch_idx: int) -> torch.Tensor:
+        """
+        Compute multi-task MSE loss for a training batch.
+
+        Params:
+            batch: Any : dict with input_ids, attention_mask, labels
+            _batch_idx: int : batch index (unused)
+        Returns:
+            torch.Tensor : scalar loss
+        """
+        return self._step(batch, "train")
+
+    def validation_step(self, batch: Any, _batch_idx: int) -> None:
+        """
+        Log validation multi-task MSE and per-target MAE.
+
+        Params:
+            batch: Any : dict with input_ids, attention_mask, labels
+            _batch_idx: int : batch index (unused)
+        Returns:
+            None
+        """
+        self._step(batch, "val")
+
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        """
+        Return AdamW with linear warmup and cosine annealing.
+
+        Params:
+            None
+        Returns:
+            dict : Lightning optimizer/scheduler config
+        """
+        opt = torch.optim.AdamW(
+            self.model.parameters(), lr=self.lr, weight_decay=self.weight_decay
+        )
+        # Linear warmup scheduler chained with cosine decay via SequentialLR
+        warmup = torch.optim.lr_scheduler.LinearLR(
+            opt, start_factor=1e-3, end_factor=1.0, total_iters=self.warmup_steps
+        )
+        cosine = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=self.t_max)
+        scheduler = torch.optim.lr_scheduler.SequentialLR(
+            opt, schedulers=[warmup, cosine], milestones=[self.warmup_steps]
+        )
+        return {
+            "optimizer": opt,
+            "lr_scheduler": {"scheduler": scheduler, "interval": "step"},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Training entry point
+# ---------------------------------------------------------------------------
+
+
+def pretrain(
+    config: dict | None = None,
+    checkpoint_dir: str | Path = "checkpoints/pretrain",
+) -> SMILESTransformer:
+    """
+    Pretrain SMILESTransformer on QM9 multi-task regression.
+
+    Params:
+        config: dict | None : hyperparameters; missing keys fall back to defaults
+        checkpoint_dir: str | Path : directory for Lightning checkpoints
+    Returns:
+        SMILESTransformer : best pretrained model with backbone weights updated
+    """
+    cfg = {
+        "targets": QM9_TARGETS,
+        "seed": 42,
+        "batch_size": 128,
+        "max_epochs": 10,
+        "patience": 3,
+        "lr": 2e-5,
+        "weight_decay": 1e-2,
+        "warmup_steps": 500,
+        "max_length": 128,
+        "d_hidden_head": 768,  # unused for pretrain head but kept for consistency
+        "qm9_split": "stratified_scaffold",
+        "wandb_project": "lipophilicity_pred",
+        "wandb_run_name": None,
+    }
+    if config:
+        cfg.update(config)
+
+    targets: list[str] = cfg["targets"]
+
+    L.seed_everything(cfg["seed"], workers=True)
+    ckpt_dir = Path(checkpoint_dir)
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Data ---
+    splits = get_qm9_splits(seed=cfg["seed"], method=cfg["qm9_split"])
+    normalizer = QM9Normalizer().fit(splits["train"], targets)
+
+    train_ds = QM9Dataset(splits["train"], targets, normalizer, cfg["max_length"])
+    val_ds = QM9Dataset(splits["valid"], targets, normalizer, cfg["max_length"])
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=cfg["batch_size"],
+        shuffle=True,
+        num_workers=4,
+        pin_memory=True,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=cfg["batch_size"],
+        shuffle=False,
+        num_workers=4,
+        pin_memory=True,
+    )
+
+    # --- Model ---
+    head = QM9PretrainHead(d_model=768, n_targets=len(targets))
+    model = SMILESTransformer(head=head, model_name=CHEMBERTA_MODEL)
+
+    # --- Loggers ---
+    wandb_logger = WandbLogger(
+        project=cfg["wandb_project"],
+        name=cfg.get("wandb_run_name"),
+        config={**cfg, "phase": "pretrain"},
+    )
+    csv_logger = CSVLogger(save_dir=str(ckpt_dir), name="logs")
+    run_name = wandb_logger.experiment.name
+
+    # --- Callbacks ---
+    early_stop = EarlyStopping(monitor="val_loss", patience=cfg["patience"], mode="min")
+    ckpt_cb = ModelCheckpoint(
+        dirpath=ckpt_dir,
+        filename=f"{run_name}-pretrain-{{epoch:03d}}-{{val_loss:.4f}}",
+        monitor="val_loss",
+        mode="min",
+        save_top_k=1,
+    )
+
+    lit = PretrainLitModule(
+        model,
+        targets=targets,
+        normalizer=normalizer,
+        lr=cfg["lr"],
+        weight_decay=cfg["weight_decay"],
+        warmup_steps=cfg["warmup_steps"],
+        t_max=cfg["max_epochs"],
+        qm9_split=cfg["qm9_split"],
+    )
+
+    trainer = L.Trainer(
+        max_epochs=cfg["max_epochs"],
+        accelerator="auto",
+        callbacks=[early_stop, ckpt_cb],
+        gradient_clip_val=1.0,
+        log_every_n_steps=10,
+        enable_progress_bar=True,
+        logger=[wandb_logger, csv_logger],
+    )
+    trainer.fit(lit, train_loader, val_loader)
+
+    import shutil
+
+    history_src = Path(csv_logger.log_dir) / "metrics.csv"
+    history_dst = ckpt_dir / "pretrain_metrics_history.csv"
+    if history_src.exists():
+        shutil.copy(history_src, history_dst)
+
+    return ckpt_cb.best_model_path
+
+
+def load_pretrained_backbone(
+    checkpoint_path: str | Path,
+    device: torch.device | None = None,
+) -> tuple[SMILESTransformer, list[str], QM9Normalizer]:
+    """
+    Restore a pretrained SMILESTransformer backbone from a Lightning checkpoint.
+
+    The returned model has no head attached — call swap_head() before use.
+    The pretrain targets and normaliser are also returned for inspection.
+
+    Params:
+        checkpoint_path: str | Path : path to the .ckpt file from pretrain()
+        device: torch.device | None : target device; defaults to CUDA if available
+    Returns:
+        tuple : (SMILESTransformer with head removed, target list, QM9Normalizer)
+    """
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    ckpt = torch.load(checkpoint_path, map_location=device, weights_only=False)
+    targets = ckpt["pretrain_targets"]
+    normalizer = QM9Normalizer.from_state_dict(ckpt["normalizer_state"])
+
+    # Rebuild model architecture to match the saved weights
+    head = QM9PretrainHead(d_model=768, n_targets=len(targets))
+    model = SMILESTransformer(head=head, model_name=CHEMBERTA_MODEL)
+
+    # Strip the "model." prefix added by Lightning
+    state = {
+        k[len("model.") :]: v
+        for k, v in ckpt["state_dict"].items()
+        if k.startswith("model.")
+    }
+    model.load_state_dict(state)
+    model = model.to(device).eval()
+
+    return model, targets, normalizer

--- a/src/qm9_data.py
+++ b/src/qm9_data.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# TDC label names for QM9 (retrieved via retrieve_label_name_list('QM9')).
+# Rotational constants A, B, C are excluded — they carry little signal for
+# property prediction tasks and are not used in standard QM9 ML benchmarks.
+QM9_TARGETS = [
+    "mu",  # dipole moment (D)
+    "alpha",  # polarisability (a₀³)
+    "homo",  # HOMO energy (Ha)
+    "lumo",  # LUMO energy (Ha)
+    "gap",  # HOMO-LUMO gap (Ha)
+    "r2",  # electronic spatial extent (a₀²)
+    "zpve",  # zero-point vibrational energy (Ha)
+    "U0",  # internal energy at 0 K (Ha)
+    "U",  # internal energy at 298 K (Ha)
+    "H",  # enthalpy at 298 K (Ha)
+    "G",  # free energy at 298 K (Ha)
+    "Cv",  # heat capacity at 298 K (cal/mol/K)
+]
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_QM9_PKL = _PROJECT_ROOT / "data" / "qm9.pkl"
+_QM9_CACHE = _PROJECT_ROOT / "data" / "qm9_smiles.parquet"
+
+
+def _patch_pandas_compat() -> None:
+    """
+    Patch pandas 2.x to load DataFrames pickled with pandas 1.x.
+
+    TDC caches data as pickle files created with pandas 1.x, where
+    BlockPlacement could be stored as a plain slice.  Pandas 2.x requires
+    BlockPlacement objects, causing a TypeError on load.  This patch
+    intercepts new_block calls and converts slice placements in-place.
+    The patch is applied at most once per process.
+
+    Params:
+        None
+    Returns:
+        None
+    """
+    import pandas.core.internals.blocks as _blocks
+    from pandas._libs.internals import BlockPlacement
+
+    if getattr(_blocks, "_compat_patched", False):
+        return
+
+    _orig = _blocks.new_block
+
+    def _patched(values, placement, ndim=2, refs=None):
+        if isinstance(placement, slice):
+            n = (
+                placement.stop
+                if placement.stop is not None
+                else (values.shape[-1] if hasattr(values, "shape") else len(values))
+            )
+            placement = BlockPlacement(range(*placement.indices(n)))
+        return _orig(values, placement, ndim=ndim, refs=refs)
+
+    _blocks.new_block = _patched
+    _blocks._compat_patched = True
+
+
+def _xyz_to_smiles(x: tuple) -> str | None:
+    """
+    Convert a QM9 (atom_types, xyz_coords) tuple to canonical SMILES.
+
+    Uses RDKit DetermineBonds to infer connectivity from 3D coordinates,
+    then strips explicit hydrogens and returns canonical SMILES.  Returns
+    None if bond determination or SMILES generation fails.  RDKit error
+    logging is suppressed here because DetermineBonds on malformed
+    structures produces high-volume valence warnings that are expected
+    and already handled by the None return.
+
+    Params:
+        x: tuple : (list[str], ndarray) — atom element symbols and Å coords
+    Returns:
+        str | None : canonical SMILES, or None on failure
+    """
+    from rdkit import Chem
+    from rdkit.Chem.rdDetermineBonds import DetermineBonds
+    from rdkit.rdBase import DisableLog, EnableLog
+
+    atoms, coords = x
+    mol = Chem.RWMol()
+    conf = Chem.Conformer(len(atoms))
+    for i, (atom, xyz) in enumerate(zip(atoms, np.array(coords))):
+        mol.AddAtom(Chem.Atom(atom))
+        conf.SetAtomPosition(i, xyz.tolist())
+    mol.AddConformer(conf)
+    DisableLog("rdApp.error")
+    try:
+        DetermineBonds(mol)
+        mol = Chem.RemoveHs(mol.GetMol())
+        result = Chem.MolToSmiles(mol)
+    except Exception:
+        result = None
+    finally:
+        EnableLog("rdApp.error")
+    return result
+
+
+def _murcko_scaffold(smiles: str) -> str:
+    """
+    Return the canonical SMILES of the generic Murcko scaffold.
+
+    Ring-free molecules (common in QM9 due to its small, simple structures)
+    return an empty string and are pooled into a single anonymous group.
+
+    Params:
+        smiles: str : SMILES string of the molecule
+    Returns:
+        str : canonical scaffold SMILES, or '' for ring-free molecules
+    """
+    from rdkit import Chem
+    from rdkit.Chem.Scaffolds.MurckoScaffold import GetScaffoldForMol
+
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return ""
+    scaffold_mol = GetScaffoldForMol(mol)
+    return Chem.MolToSmiles(scaffold_mol) if scaffold_mol.GetNumAtoms() > 0 else ""
+
+
+def _build_smiles_df() -> pd.DataFrame:
+    """
+    Load the raw QM9 pickle, convert 3D structures to SMILES, and drop failures.
+
+    TDC's QM9 stores molecules as (atom_types, xyz_coords) tuples.  TDC's own
+    multi-label API is broken for list label_name inputs (fuzzy_search calls
+    name.lower() on a list), so we load the raw pickle directly and use RDKit
+    DetermineBonds for SMILES generation.
+
+    Params:
+        None
+    Returns:
+        pd.DataFrame : columns Drug (SMILES), Drug_ID, and 12 QM9 targets
+    """
+    _patch_pandas_compat()
+    raw = pd.read_pickle(_QM9_PKL)
+    raw["Drug"] = raw["X"].apply(_xyz_to_smiles)
+    raw["Drug_ID"] = raw["ID"]
+    keep_cols = ["Drug", "Drug_ID"] + QM9_TARGETS
+    df = raw[keep_cols].dropna(subset=["Drug"] + QM9_TARGETS).reset_index(drop=True)
+    return df
+
+
+def load_qm9() -> pd.DataFrame:
+    """
+    Load the QM9 dataset with SMILES strings and 12 standard QM targets.
+
+    On first call, the raw TDC pickle is loaded, 3D structures are converted to
+    SMILES via RDKit DetermineBonds, and the result is cached as parquet in
+    data/qm9_smiles.parquet for fast subsequent loads.  Molecules where SMILES
+    conversion fails (~1%) are silently dropped.
+
+    Params:
+        None
+    Returns:
+        pd.DataFrame : ~133k rows; columns Drug (SMILES), Drug_ID, + 12 targets
+    """
+    if _QM9_CACHE.exists():
+        return pd.read_parquet(_QM9_CACHE)
+    print("Building QM9 SMILES cache (one-time, ~30s)...")
+    df = _build_smiles_df()
+    _QM9_CACHE.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(_QM9_CACHE, index=False)
+    print(f"Cached {len(df):,} molecules to {_QM9_CACHE}")
+    return df
+
+
+def get_qm9_splits(
+    seed: int = 42,
+    method: str = "stratified_scaffold",
+    train_frac: float = 0.8,
+    val_frac: float = 0.1,
+    n_strata: int = 5,
+    stratify_on: str = "gap",
+) -> dict[str, pd.DataFrame]:
+    """
+    Return a train / valid / test split of QM9.
+
+    Two split strategies are supported:
+
+    ``"random"``
+        Plain stratified random split — molecules are assigned purely by
+        shuffling.  Structurally similar molecules may appear across splits.
+
+    ``"stratified_scaffold"``
+        Molecules are first grouped by their generic Murcko scaffold so
+        structurally similar molecules always land in the same split.  Scaffold
+        groups are then binned into ``n_strata`` quantile strata by median value
+        of ``stratify_on`` (default: HOMO-LUMO gap), and a stratified shuffle
+        split is applied at the scaffold-group level.  This ensures each split
+        sees a representative cross-section of the QM9 property distribution
+        while preserving scaffold integrity.  QM9 contains many ring-free
+        molecules (linear aliphatics); these are pooled into a single
+        scaffold group.
+
+    Params:
+        seed: int : random seed for reproducibility
+        method: str : 'random' or 'stratified_scaffold'
+        train_frac: float : fraction of molecules for training
+        val_frac: float : fraction of molecules for validation
+        n_strata: int : number of quantile bins for property stratification
+        stratify_on: str : QM9 target column used to stratify scaffold groups
+    Returns:
+        dict[str, pd.DataFrame] : keys 'train', 'valid', 'test'
+    """
+    if method == "random":
+        return _random_split(seed=seed, train_frac=train_frac, val_frac=val_frac)
+    if method == "stratified_scaffold":
+        return _stratified_scaffold_split(
+            seed=seed,
+            train_frac=train_frac,
+            val_frac=val_frac,
+            n_strata=n_strata,
+            stratify_on=stratify_on,
+        )
+    raise ValueError(
+        f"Unknown method '{method}'. Use 'random' or 'stratified_scaffold'."
+    )
+
+
+def _random_split(
+    seed: int,
+    train_frac: float,
+    val_frac: float,
+) -> dict[str, pd.DataFrame]:
+    """
+    Return a purely random 80/10/10 split of QM9.
+
+    Params:
+        seed: int : random seed
+        train_frac: float : training fraction
+        val_frac: float : validation fraction
+    Returns:
+        dict[str, pd.DataFrame] : keys 'train', 'valid', 'test'
+    """
+    from sklearn.model_selection import train_test_split
+
+    test_frac = 1.0 - train_frac - val_frac
+    df = load_qm9()
+    train_val, test = train_test_split(df, test_size=test_frac, random_state=seed)
+    train, valid = train_test_split(
+        train_val, test_size=val_frac / (train_frac + val_frac), random_state=seed
+    )
+    return {
+        "train": train.reset_index(drop=True),
+        "valid": valid.reset_index(drop=True),
+        "test": test.reset_index(drop=True),
+    }
+
+
+def _stratified_scaffold_split(
+    seed: int,
+    train_frac: float,
+    val_frac: float,
+    n_strata: int,
+    stratify_on: str,
+) -> dict[str, pd.DataFrame]:
+    """
+    Return a stratified Murcko scaffold split of QM9.
+
+    Scaffold groups are stratified by the median value of ``stratify_on``
+    across molecules sharing that scaffold.  The split mirrors the approach
+    used for the logD lipophilicity dataset in src/data.py.
+
+    Params:
+        seed: int : random seed
+        train_frac: float : training fraction
+        val_frac: float : validation fraction
+        n_strata: int : number of quantile strata
+        stratify_on: str : QM9 target column name for scaffold stratification
+    Returns:
+        dict[str, pd.DataFrame] : keys 'train', 'valid', 'test'
+    """
+    from sklearn.model_selection import StratifiedShuffleSplit
+
+    test_frac = 1.0 - train_frac - val_frac
+
+    df = load_qm9().copy()
+    df["_scaffold"] = df["Drug"].map(_murcko_scaffold)
+
+    scaffold_stats = (
+        df.groupby("_scaffold")[stratify_on]
+        .agg(median="median", n="count")
+        .reset_index()
+    )
+
+    large_mask = scaffold_stats["n"] > 0.05 * len(df)
+    for _, row in scaffold_stats[large_mask].iterrows():
+        warnings.warn(
+            f"Scaffold '{row['_scaffold'][:60]}' contains {row['n']} molecules "
+            f"({100 * row['n'] / len(df):.1f}% of dataset) and will be assigned "
+            f"entirely to one split.",
+            stacklevel=2,
+        )
+
+    scaffold_stats = scaffold_stats.sort_values("median").reset_index(drop=True)
+    scaffold_stats["_stratum"] = (
+        np.arange(len(scaffold_stats)) * n_strata // len(scaffold_stats)
+    ).astype(int)
+
+    sss1 = StratifiedShuffleSplit(
+        n_splits=1, test_size=(val_frac + test_frac), random_state=seed
+    )
+    _, temp_idx = next(sss1.split(scaffold_stats, scaffold_stats["_stratum"]))
+
+    temp = scaffold_stats.iloc[temp_idx].reset_index(drop=True)
+    sss2 = StratifiedShuffleSplit(
+        n_splits=1,
+        test_size=test_frac / (val_frac + test_frac),
+        random_state=seed,
+    )
+    val_idx, test_idx = next(sss2.split(temp, temp["_stratum"]))
+    valid_scaffolds = set(temp.iloc[val_idx]["_scaffold"])
+    test_scaffolds = set(temp.iloc[test_idx]["_scaffold"])
+
+    def _assign(scaffold: str) -> str:
+        if scaffold in valid_scaffolds:
+            return "valid"
+        if scaffold in test_scaffolds:
+            return "test"
+        return "train"
+
+    df["_split"] = df["_scaffold"].map(_assign)
+    df = df.drop(columns=["_scaffold"])
+
+    return {
+        split: df[df["_split"] == split].drop(columns=["_split"]).reset_index(drop=True)
+        for split in ("train", "valid", "test")
+    }
+
+
+class QM9Normalizer:
+    """
+    Per-target z-score normaliser fitted on the QM9 training split.
+
+    QM9 targets span very different scales and units (eV, Bohr, kcal/mol).
+    Normalising each target independently to zero mean and unit variance lets
+    the multi-task loss treat all targets equally without hand-tuned weights.
+
+    The normaliser must be fitted on the training split only and the fitted
+    statistics are saved alongside the pretrained checkpoint so they can be
+    used at inference time (e.g. to denormalise predictions for inspection).
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialise an unfitted normaliser.
+
+        Params:
+            None
+        Returns:
+            None
+        """
+        self.mean_: pd.Series | None = None
+        self.std_: pd.Series | None = None
+
+    def fit(self, df: pd.DataFrame, targets: list[str]) -> "QM9Normalizer":
+        """
+        Compute per-target mean and std from a training DataFrame.
+
+        Params:
+            df: pd.DataFrame : training split containing target columns
+            targets: list[str] : column names of the targets to normalise
+        Returns:
+            QM9Normalizer : self, for chaining
+        """
+        self.mean_ = df[targets].mean()
+        self.std_ = df[targets].std().clip(lower=1e-8)
+        return self
+
+    def transform(self, df: pd.DataFrame, targets: list[str]) -> np.ndarray:
+        """
+        Apply z-score normalisation and return a float32 array.
+
+        Params:
+            df: pd.DataFrame : DataFrame containing target columns
+            targets: list[str] : column names to normalise (must match fit)
+        Returns:
+            np.ndarray : shape (n, len(targets)), dtype float32
+        """
+        if self.mean_ is None:
+            raise RuntimeError("Call fit() before transform().")
+        normed = (df[targets] - self.mean_[targets]) / self.std_[targets]
+        return normed.values.astype(np.float32)
+
+    def state_dict(self) -> dict:
+        """
+        Return serialisable mean/std arrays for checkpoint embedding.
+
+        Params:
+            None
+        Returns:
+            dict : keys 'mean' and 'std' as lists, plus 'targets'
+        """
+        return {
+            "mean": self.mean_.tolist(),
+            "std": self.std_.tolist(),
+            "targets": self.mean_.index.tolist(),
+        }
+
+    @classmethod
+    def from_state_dict(cls, state: dict) -> "QM9Normalizer":
+        """
+        Reconstruct a normaliser from a saved state dict.
+
+        Params:
+            state: dict : output of state_dict()
+        Returns:
+            QM9Normalizer : fitted normaliser
+        """
+        norm = cls()
+        norm.mean_ = pd.Series(state["mean"], index=state["targets"])
+        norm.std_ = pd.Series(state["std"], index=state["targets"])
+        return norm

--- a/src/transformer_model.py
+++ b/src/transformer_model.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from transformers import AutoModelForMaskedLM, AutoTokenizer
+
+CHEMBERTA_MODEL = "seyonec/ChemBERTa-zinc-base-v1"
+_TOKENIZER_CACHE: AutoTokenizer | None = None
+
+
+def get_tokenizer() -> AutoTokenizer:
+    """
+    Return the ChemBERTa tokenizer, loading it once and caching it in-process.
+
+    Params:
+        None
+    Returns:
+        AutoTokenizer : ChemBERTa tokenizer
+    """
+    global _TOKENIZER_CACHE
+    if _TOKENIZER_CACHE is None:
+        _TOKENIZER_CACHE = AutoTokenizer.from_pretrained(CHEMBERTA_MODEL)
+    return _TOKENIZER_CACHE
+
+
+def tokenize(smiles: list[str], max_length: int = 128) -> dict[str, torch.Tensor]:
+    """
+    Tokenize a list of SMILES strings for ChemBERTa.
+
+    Params:
+        smiles: list[str] : SMILES strings to tokenize
+        max_length: int : maximum token sequence length (default 128)
+    Returns:
+        dict[str, torch.Tensor] : 'input_ids' and 'attention_mask' tensors,
+            shape (n, max_length)
+    """
+    tokenizer = get_tokenizer()
+    return tokenizer(
+        smiles,
+        padding="max_length",
+        truncation=True,
+        max_length=max_length,
+        return_tensors="pt",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression heads
+# ---------------------------------------------------------------------------
+
+
+class QM9PretrainHead(nn.Module):
+    """Single linear layer mapping [CLS] → n_targets normalised QM9 values."""
+
+    def __init__(self, d_model: int, n_targets: int) -> None:
+        """
+        Initialise the QM9 pretraining head.
+
+        Params:
+            d_model: int : ChemBERTa hidden dimension (768)
+            n_targets: int : number of QM9 regression targets
+        Returns:
+            None
+        """
+        super().__init__()
+        self.linear = nn.Linear(d_model, n_targets)
+
+    def forward(self, cls_token: torch.Tensor) -> torch.Tensor:
+        """
+        Project [CLS] to QM9 target predictions.
+
+        Params:
+            cls_token: torch.Tensor : shape (batch, d_model)
+        Returns:
+            torch.Tensor : shape (batch, n_targets)
+        """
+        return self.linear(cls_token)
+
+
+class LogDFinetuneHead(nn.Module):
+    """MLP head mapping [CLS] → scalar logD prediction."""
+
+    def __init__(self, d_model: int, d_hidden: int = 256, dropout: float = 0.1) -> None:
+        """
+        Initialise the logD fine-tuning head.
+
+        Params:
+            d_model: int : ChemBERTa hidden dimension (768)
+            d_hidden: int : MLP hidden layer size
+            dropout: float : dropout probability
+        Returns:
+            None
+        """
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.LayerNorm(d_model),
+            nn.Linear(d_model, d_hidden),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(d_hidden, 1),
+        )
+
+    def forward(self, cls_token: torch.Tensor) -> torch.Tensor:
+        """
+        Project [CLS] to a scalar logD prediction.
+
+        Params:
+            cls_token: torch.Tensor : shape (batch, d_model)
+        Returns:
+            torch.Tensor : shape (batch, 1)
+        """
+        return self.net(cls_token)
+
+
+# ---------------------------------------------------------------------------
+# Main model
+# ---------------------------------------------------------------------------
+
+
+class SMILESTransformer(nn.Module):
+    """
+    ChemBERTa backbone with a swappable regression head.
+
+    The backbone is always unfrozen — for pretraining (QM9 multi-task) the
+    head is a QM9PretrainHead; after phase 1 the head is swapped for a
+    LogDFinetuneHead and the whole model is fine-tuned end-to-end on logD.
+
+    The model accepts pre-tokenized inputs (input_ids, attention_mask) to
+    keep tokenization out of the forward pass and avoid re-loading the
+    tokenizer on each batch.
+    """
+
+    def __init__(self, head: nn.Module, model_name: str = CHEMBERTA_MODEL) -> None:
+        """
+        Initialise the transformer with ChemBERTa backbone and a head.
+
+        Params:
+            head: nn.Module : QM9PretrainHead or LogDFinetuneHead
+            model_name: str : HuggingFace model ID for the backbone
+        Returns:
+            None
+        """
+        super().__init__()
+        # Load as ForMaskedLM so weight-tied embeddings are correctly resolved
+        # (safetensors de-duplicates embeddings.word_embeddings.weight ↔
+        # lm_head.decoder.weight; AutoModel would leave the embedding table
+        # randomly initialized).  We extract only the encoder backbone and
+        # discard the LM head.
+        import transformers as _hf
+
+        _prev_level = _hf.logging.get_verbosity()
+        _hf.logging.set_verbosity_error()
+        _full = AutoModelForMaskedLM.from_pretrained(model_name)
+        _hf.logging.set_verbosity(_prev_level)
+        self.backbone = _full.roberta
+        del _full
+        self.head = head
+        self.train()
+
+    @property
+    def d_model(self) -> int:
+        """
+        Return the backbone hidden dimension.
+
+        Params:
+            None
+        Returns:
+            int : hidden size of the ChemBERTa backbone
+        """
+        return self.backbone.config.hidden_size
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Run backbone and head, returning predictions.
+
+        Params:
+            input_ids: torch.Tensor : shape (batch, seq_len)
+            attention_mask: torch.Tensor : shape (batch, seq_len)
+        Returns:
+            torch.Tensor : head output, shape depends on head type
+        """
+        out = self.backbone(input_ids=input_ids, attention_mask=attention_mask)
+        cls = out.last_hidden_state[:, 0, :]  # [CLS] token
+        return self.head(cls)
+
+    def swap_head(self, new_head: nn.Module) -> None:
+        """
+        Replace the current head in-place.
+
+        Params:
+            new_head: nn.Module : replacement head module
+        Returns:
+            None
+        """
+        self.head = new_head


### PR DESCRIPTION
## Summary/Issue

Closes #7. Implements a two-phase SMILES transformer pretraining pipeline as a parallel architecture to the existing ChemBERTa + chemprop GNN. Phase 1 pretrains a ChemBERTa backbone on all 12 quantum-mechanical properties from QM9 via multi-task regression; Phase 2 fine-tunes the pretrained backbone on the logD TDC task. The goal is to test whether learning from QM-level molecular physics (electronic structure, thermodynamics, vibrational energy) transfers to experimental lipophilicity prediction.

## Key Features + Dependencies

- Added `src/transformer_model.py` — `SMILESTransformer` with a swappable head (`QM9PretrainHead` for pretraining, `LogDFinetuneHead` for fine-tuning). Backbone is `seyonec/ChemBERTa-zinc-base-v1` loaded via `AutoModelForMaskedLM` to correctly resolve weight-tied embeddings in safetensors checkpoints. Module-level tokenizer cache avoids re-loading on each batch.
- Added `src/qm9_data.py` — loads TDC's QM9 pickle directly (bypassing TDC's broken multi-label `fuzzy_search` API), converts 3D atom coordinates → canonical SMILES via RDKit `DetermineBonds` (~30s one-time, then cached as `data/qm9_smiles.parquet`). Supports `random` and `stratified_scaffold` splits (scaffold groups stratified by median HOMO-LUMO gap, mirroring the logD split strategy). `QM9Normalizer` z-scores each target independently and is embedded in the pretrain checkpoint.
- Added `src/pretrain_transformer.py` — `PretrainLitModule` with multi-task MSE loss, per-target MAE logging to wandb, and a `SequentialLR` schedule (linear warmup + cosine annealing). Checkpoint embeds `pretrain_targets`, `normalizer_state`, and `qm9_split` for provenance. `load_pretrained_backbone` restores backbone + normalizer from a `.ckpt` file.
- Added `src/finetune_transformer.py` — `FinetuneLitModule` fine-tunes the full model (backbone + new `LogDFinetuneHead`) on the TDC AstraZeneca logD scaffold split. `pretrained_checkpoint=None` gives a no-pretraining baseline. Checkpoint embeds `head_kwargs` and `pretrained_checkpoint` path.
- Added `scripts/pretrain_qm9.py` and `scripts/finetune_logd.py` — CLI entry points for both phases with full hyperparameter override support.
- Added `notebooks/04_transformer.py` — Marimo evaluation dashboard: per-split metrics table, parity plots with KDE marginals, and training/validation loss curves for both phases.
- Updated `pixi.toml` — added `pretrain-transformer`, `finetune-transformer`, and `notebook-transformer` tasks.
- Fixed safetensors compatibility: `AutoModelForMaskedLM.from_pretrained` used instead of `AutoModel` to correctly resolve weight-tied embeddings deduplicated in safetensors format; `self.train()` added to `SMILESTransformer.__init__` to reset eval mode set by `from_pretrained`.

## Tests/Test Steps

- [ ] `pixi run pretrain-transformer --qm9-split random` completes at least one epoch without error; checkpoint written to `checkpoints/pretrain/`
- [ ] `pixi run pretrain-transformer --qm9-split stratified_scaffold` likewise
- [ ] `pixi run finetune-transformer --pretrained-checkpoint checkpoints/pretrain/<run>.ckpt` completes and prints RMSE/MAE/R² for train/valid/test
- [ ] `pixi run finetune-transformer` (no checkpoint) runs as a no-pretraining baseline
- [ ] `pixi run notebook-transformer` opens the Marimo dashboard; metrics table and parity plots render when checkpoint paths are filled in
- [ ] `pixi run python -c "from src.qm9_data import load_qm9; df = load_qm9(); assert df.shape[0] > 125000"` passes from the parquet cache

## Story

The TDC `QM` class accepts `label_name` as a string but was passed a list, causing `fuzzy_search` to call `.lower()` on the list and silently `sys.exit`. The workaround loads the raw pickle directly and generates SMILES with RDKit `DetermineBonds` — about 5% of QM9 molecules fail bond determination and are dropped. The safetensors loading issue arose because ChemBERTa's pretrained weights use weight tying (`embeddings.word_embeddings` ↔ `lm_head.decoder`); safetensors deduplicates these, so loading via `AutoModel` left the embedding table randomly initialized. Loading via `AutoModelForMaskedLM` and extracting `.roberta` resolves the tying correctly.

## Related Issues / Branches

- Upstream: #5 (stratified scaffold split), #2 (GNN + ChemBERTa baseline)
- Downstream: ablation analysis comparing pretraining target groups (All 12, Electronic only, Thermodynamic only, None) against GNN performance

## Other Notes

- `data/qm9_smiles.parquet` should be added to `.gitignore` if not already (134k molecules, ~15 MB).
- The HF hub cache fix is local to this machine; upgrading torch to ≥ 2.6 in `pixi.toml` is the permanent fix across environments.